### PR TITLE
fix: lazily re-evaluate screen queries on each access

### DIFF
--- a/src/testing-core.ts
+++ b/src/testing-core.ts
@@ -160,12 +160,13 @@ export const createRenderMetricsEmitter = (
 };
 
 export const createScreen = (): Screen => {
-  const baseScreenQueries = getQueriesForElement(document.body);
-
-  return new Proxy(baseScreenQueries, {
-    get(target, prop, receiver) {
-      const value = Reflect.get(target, prop, receiver);
-      return typeof value === 'function' ? value.bind(target) : value;
+  return new Proxy({} as Screen, {
+    get(_target, prop) {
+      const baseScreenQueries = getQueriesForElement(document.body);
+      const value = Reflect.get(baseScreenQueries, prop, baseScreenQueries);
+      return typeof value === 'function'
+        ? value.bind(baseScreenQueries)
+        : value;
     },
   }) as Screen;
 };


### PR DESCRIPTION
## Problem

`createScreen()` in `testing-core.ts` called `getQueriesForElement(document.body)` once at screen creation time and cached those query bindings.

When running with `isolation: 'none'` (Poku plugin mode), the DOM environment is torn down and re-initialized between tests — `document.body` is replaced with a fresh element. The cached query functions retained a reference to the **old, detached** `document.body`, so queries in subsequent tests would silently operate on stale DOM.

## Fix

Wrap the screen in a `Proxy` that calls `getQueriesForElement(document.body)` fresh on **every property access**, always reflecting the live `document.body`:

```diff
-  const baseScreenQueries = getQueriesForElement(document.body);
-
-  return new Proxy(baseScreenQueries, {
-    get(target, prop, receiver) {
-      const value = Reflect.get(target, prop, receiver);
-      return typeof value === 'function' ? value.bind(target) : value;
+  return new Proxy({} as Screen, {
+    get(_target, prop) {
+      const baseScreenQueries = getQueriesForElement(document.body);
+      const value = Reflect.get(baseScreenQueries, prop, baseScreenQueries);
+      return typeof value === 'function'
+        ? value.bind(baseScreenQueries)
+        : value;
     },
   }) as Screen;
```

This is a zero-overhead change in normal (fresh-DOM) usage and fixes stale-query bugs in `isolation: 'none'` mode used by both `@pokujs/react` and `@pokujs/vue`.
