### PR TITLE
feat: add commandBuilder hook to FrameworkDescriptor

### DIFF
--- a/src/plugin-factory.ts
+++ b/src/plugin-factory.ts
@@ -91,14 +91,9 @@ export const createFrameworkTestingPluginFactory = (
         const runtime = command[0];
         if (!runtime) return command;
 
-        const result = buildRunnerCommand({
-          runtime,
-          command,
-          file,
-          domSetupPath,
-          runtimeOptionArgs,
-          extensions,
-        });
+        const result = descriptor.commandBuilder
+          ? descriptor.commandBuilder({ runtime, command, file, domSetupPath, runtimeOptionArgs })
+          : buildRunnerCommand({ runtime, command, file, domSetupPath, runtimeOptionArgs, extensions });
 
         if (!result.shouldHandle) return command;
         return result.command;

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,4 +55,11 @@ export type FrameworkDescriptor = {
   metricMessageType: string;
   metricBatchMessageType: string;
   testFileExtensions?: string[];
+  commandBuilder?: (input: {
+    runtime: string;
+    command: string[];
+    file: string;
+    domSetupPath: string;
+    runtimeOptionArgs: string[];
+  }) => { shouldHandle: boolean; command: string[] };
 };


### PR DESCRIPTION
## Summary

Adds an optional `commandBuilder` field to `FrameworkDescriptor`. When present, `createFrameworkTestingPluginFactory` delegates to it inside the `runner` hook instead of calling the default `buildRunnerCommand`.

## Motivation

`@pokujs/vue` needs a custom runner command builder to compile `.vue` SFC files into a pre-transpiled runtime graph before passing the file to Bun/Deno. Without this hook the only option was to re-implement the full `definePlugin` lifecycle (setup, runner, onTestProcess, teardown, metrics) entirely in the Vue package — duplicating ~120 lines already provided by this factory.

## Changes

- `src/types.ts`: added optional `commandBuilder` to `FrameworkDescriptor`
- `src/plugin-factory.ts`: the factory `runner` hook checks `descriptor.commandBuilder` first; falls through to the default `buildRunnerCommand` if not set

## Compatibility

No breaking change. `commandBuilder` is optional; existing consumers (e.g. `@pokujs/react`) are unaffected. The default path in `plugin-factory.ts` is unchanged when `commandBuilder` is absent.
