### PR TITLE
feat: add ALS-based test scope hooks foundation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,301 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@pokujs/dom",
+      "dependencies": {
+        "@pokujs/scope-hooks": "file:../scope-hooks",
+        "@testing-library/dom": "^10.4.1",
+      },
+      "devDependencies": {
+        "@happy-dom/global-registrator": "^20.8.9",
+        "@types/jsdom": "^28.0.1",
+        "@types/node": "^25.5.0",
+        "cross-env": "^10.1.0",
+        "happy-dom": "^20.8.9",
+        "jsdom": "^26.1.0",
+        "poku": "^4.3.0",
+        "rimraf": "^6.0.1",
+        "tsx": "^4.21.0",
+        "typescript": "^6.0.2",
+      },
+      "peerDependencies": {
+        "happy-dom": ">=20",
+        "jsdom": ">=22",
+        "poku": ">=4.1.0",
+      },
+      "optionalPeers": [
+        "happy-dom",
+        "jsdom",
+      ],
+    },
+  },
+  "packages": {
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@3.1.0", "", { "dependencies": { "@csstools/color-helpers": "^5.1.0", "@csstools/css-calc": "^2.1.4" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
+
+    "@epic-web/invariant": ["@epic-web/invariant@1.0.0", "", {}, "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.9.0" } }, "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw=="],
+
+    "@ianvs/prettier-plugin-sort-imports": ["@ianvs/prettier-plugin-sort-imports@4.7.1", "", { "dependencies": { "@babel/generator": "^7.26.2", "@babel/parser": "^7.26.2", "@babel/traverse": "^7.25.9", "@babel/types": "^7.26.0", "semver": "^7.5.2" }, "peerDependencies": { "@prettier/plugin-oxc": "^0.0.4 || ^0.1.0", "@vue/compiler-sfc": "2.7.x || 3.x", "content-tag": "^4.0.0", "prettier": "2 || 3 || ^4.0.0-0", "prettier-plugin-ember-template-tag": "^2.1.0" }, "optionalPeers": ["@prettier/plugin-oxc", "@vue/compiler-sfc", "content-tag", "prettier-plugin-ember-template-tag"] }, "sha512-jmTNYGlg95tlsoG3JLCcuC4BrFELJtLirLAkQW/71lXSyOhVt/Xj7xWbbGcuVbNq1gwWgSyMrPjJc9Z30hynVw=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@pokujs/scope-hooks": ["@pokujs/scope-hooks@file:../scope-hooks", { "devDependencies": { "@ianvs/prettier-plugin-sort-imports": "^4.7.0", "@types/node": "^25.5.0", "poku": "4.2.2-canary.24d7783d", "prettier": "^3.6.2", "rimraf": "^6.0.1", "tsx": "^4.21.0", "typescript": "^6.0.2" }, "peerDependencies": { "poku": ">=4.2.2-canary.24d7783d" } }],
+
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
+    "@types/jsdom": ["@types/jsdom@28.0.1", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0", "undici-types": "^7.21.0" } }, "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "cross-env": ["cross-env@10.1.0", "", { "dependencies": { "@epic-web/invariant": "^1.0.0", "cross-spawn": "^7.0.6" }, "bin": { "cross-env": "dist/bin/cross-env.js", "cross-env-shell": "dist/bin/cross-env-shell.js" } }, "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
+
+    "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "poku": ["poku@4.3.0", "", { "bin": { "poku": "lib/bin/index.js" } }, "sha512-s6xHA93lzirvScBuW5UxUAbx4Cw6C/5MEMTe/27jTtLkDmIsWNpUH2CiMbSOKMxLGj7C3JoM2zfacu3kCrlk3Q=="],
+
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "rimraf": ["rimraf@6.1.3", "", { "dependencies": { "glob": "^13.0.3", "package-json-from-dist": "^1.0.1" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA=="],
+
+    "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
+
+    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
+
+    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
+
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@7.25.0", "", {}, "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "@pokujs/scope-hooks/poku": ["poku@4.2.2-canary.24d7783d", "", { "bin": { "poku": "lib/bin/index.js" } }, "sha512-sEU2gv2ZLgRySpym/sSuQk0hvvwzbdnDqnq0Msu+zhKcQlv4mTuFbJSB70eOEGpnxQB3sBmT80A6kcUJFCqjwA=="],
+
+    "@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "data-urls/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "jsdom/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "path-scurry/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+  }
+}

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,666 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:@happy-dom/global-registrator@^20.8.9": "20.9.0",
+    "npm:@testing-library/dom@^10.4.1": "10.4.1",
+    "npm:@types/jsdom@^28.0.1": "28.0.1",
+    "npm:@types/node@^25.5.0": "25.6.0",
+    "npm:cross-env@^10.1.0": "10.1.0",
+    "npm:happy-dom@^20.8.9": "20.9.0",
+    "npm:jsdom@^26.1.0": "26.1.0",
+    "npm:poku@*": "4.3.0",
+    "npm:poku@^4.3.0": "4.3.0",
+    "npm:rimraf@^6.0.1": "6.1.3",
+    "npm:tsx@^4.21.0": "4.21.0",
+    "npm:typescript@^6.0.2": "6.0.3"
+  },
+  "npm": {
+    "@asamuzakjp/css-color@3.2.0_@csstools+css-parser-algorithms@3.0.5__@csstools+css-tokenizer@3.0.4_@csstools+css-tokenizer@3.0.4": {
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dependencies": [
+        "@csstools/css-calc",
+        "@csstools/css-color-parser",
+        "@csstools/css-parser-algorithms",
+        "@csstools/css-tokenizer",
+        "lru-cache@10.4.3"
+      ]
+    },
+    "@babel/code-frame@7.29.0": {
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dependencies": [
+        "@babel/helper-validator-identifier",
+        "js-tokens",
+        "picocolors"
+      ]
+    },
+    "@babel/helper-validator-identifier@7.28.5": {
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="
+    },
+    "@babel/runtime@7.29.2": {
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
+    },
+    "@csstools/color-helpers@5.1.0": {
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="
+    },
+    "@csstools/css-calc@2.1.4_@csstools+css-parser-algorithms@3.0.5__@csstools+css-tokenizer@3.0.4_@csstools+css-tokenizer@3.0.4": {
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dependencies": [
+        "@csstools/css-parser-algorithms",
+        "@csstools/css-tokenizer"
+      ]
+    },
+    "@csstools/css-color-parser@3.1.0_@csstools+css-parser-algorithms@3.0.5__@csstools+css-tokenizer@3.0.4_@csstools+css-tokenizer@3.0.4": {
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dependencies": [
+        "@csstools/color-helpers",
+        "@csstools/css-calc",
+        "@csstools/css-parser-algorithms",
+        "@csstools/css-tokenizer"
+      ]
+    },
+    "@csstools/css-parser-algorithms@3.0.5_@csstools+css-tokenizer@3.0.4": {
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dependencies": [
+        "@csstools/css-tokenizer"
+      ]
+    },
+    "@csstools/css-tokenizer@3.0.4": {
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="
+    },
+    "@epic-web/invariant@1.0.0": {
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA=="
+    },
+    "@esbuild/aix-ppc64@0.27.7": {
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/android-arm64@0.27.7": {
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/android-arm@0.27.7": {
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/android-x64@0.27.7": {
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "os": ["android"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/darwin-arm64@0.27.7": {
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/darwin-x64@0.27.7": {
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/freebsd-arm64@0.27.7": {
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/freebsd-x64@0.27.7": {
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/linux-arm64@0.27.7": {
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/linux-arm@0.27.7": {
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/linux-ia32@0.27.7": {
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/linux-loong64@0.27.7": {
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@esbuild/linux-mips64el@0.27.7": {
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
+    "@esbuild/linux-ppc64@0.27.7": {
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/linux-riscv64@0.27.7": {
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@esbuild/linux-s390x@0.27.7": {
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@esbuild/linux-x64@0.27.7": {
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/netbsd-arm64@0.27.7": {
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/netbsd-x64@0.27.7": {
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openbsd-arm64@0.27.7": {
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/openbsd-x64@0.27.7": {
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openharmony-arm64@0.27.7": {
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "os": ["openharmony"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/sunos-x64@0.27.7": {
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/win32-arm64@0.27.7": {
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/win32-ia32@0.27.7": {
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/win32-x64@0.27.7": {
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@happy-dom/global-registrator@20.9.0": {
+      "integrity": "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw==",
+      "dependencies": [
+        "@types/node@25.6.0",
+        "happy-dom"
+      ]
+    },
+    "@testing-library/dom@10.4.1": {
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dependencies": [
+        "@babel/code-frame",
+        "@babel/runtime",
+        "@types/aria-query",
+        "aria-query",
+        "dom-accessibility-api",
+        "lz-string",
+        "picocolors",
+        "pretty-format"
+      ]
+    },
+    "@types/aria-query@5.0.4": {
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
+    },
+    "@types/jsdom@28.0.1": {
+      "integrity": "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==",
+      "dependencies": [
+        "@types/node@22.15.15",
+        "@types/tough-cookie",
+        "parse5",
+        "undici-types@7.25.0"
+      ]
+    },
+    "@types/node@22.15.15": {
+      "integrity": "sha512-R5muMcZob3/Jjchn5LcO8jdKwSCbzqmPB6ruBxMcf9kbxtniZHP327s6C37iOfuw8mbKK3cAQa7sEl7afLrQ8A==",
+      "dependencies": [
+        "undici-types@6.21.0"
+      ]
+    },
+    "@types/node@25.6.0": {
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dependencies": [
+        "undici-types@7.19.2"
+      ]
+    },
+    "@types/tough-cookie@4.0.5": {
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
+    },
+    "@types/whatwg-mimetype@3.0.2": {
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="
+    },
+    "@types/ws@8.18.1": {
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": [
+        "@types/node@22.15.15"
+      ]
+    },
+    "agent-base@7.1.4": {
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
+    },
+    "ansi-regex@5.0.1": {
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "ansi-styles@5.2.0": {
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
+    },
+    "aria-query@5.3.0": {
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dependencies": [
+        "dequal"
+      ]
+    },
+    "balanced-match@4.0.4": {
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
+    },
+    "brace-expansion@5.0.5": {
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dependencies": [
+        "balanced-match"
+      ]
+    },
+    "cross-env@10.1.0": {
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dependencies": [
+        "@epic-web/invariant",
+        "cross-spawn"
+      ],
+      "bin": true
+    },
+    "cross-spawn@7.0.6": {
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": [
+        "path-key",
+        "shebang-command",
+        "which"
+      ]
+    },
+    "cssstyle@4.6.0": {
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dependencies": [
+        "@asamuzakjp/css-color",
+        "rrweb-cssom"
+      ]
+    },
+    "data-urls@5.0.0": {
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dependencies": [
+        "whatwg-mimetype@4.0.0",
+        "whatwg-url"
+      ]
+    },
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "decimal.js@10.6.0": {
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="
+    },
+    "dequal@2.0.3": {
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
+    },
+    "dom-accessibility-api@0.5.16": {
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="
+    },
+    "entities@6.0.1": {
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="
+    },
+    "entities@7.0.1": {
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="
+    },
+    "esbuild@0.27.7": {
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "optionalDependencies": [
+        "@esbuild/aix-ppc64",
+        "@esbuild/android-arm",
+        "@esbuild/android-arm64",
+        "@esbuild/android-x64",
+        "@esbuild/darwin-arm64",
+        "@esbuild/darwin-x64",
+        "@esbuild/freebsd-arm64",
+        "@esbuild/freebsd-x64",
+        "@esbuild/linux-arm",
+        "@esbuild/linux-arm64",
+        "@esbuild/linux-ia32",
+        "@esbuild/linux-loong64",
+        "@esbuild/linux-mips64el",
+        "@esbuild/linux-ppc64",
+        "@esbuild/linux-riscv64",
+        "@esbuild/linux-s390x",
+        "@esbuild/linux-x64",
+        "@esbuild/netbsd-arm64",
+        "@esbuild/netbsd-x64",
+        "@esbuild/openbsd-arm64",
+        "@esbuild/openbsd-x64",
+        "@esbuild/openharmony-arm64",
+        "@esbuild/sunos-x64",
+        "@esbuild/win32-arm64",
+        "@esbuild/win32-ia32",
+        "@esbuild/win32-x64"
+      ],
+      "scripts": true,
+      "bin": true
+    },
+    "fsevents@2.3.3": {
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "os": ["darwin"],
+      "scripts": true
+    },
+    "get-tsconfig@4.14.0": {
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dependencies": [
+        "resolve-pkg-maps"
+      ]
+    },
+    "glob@13.0.6": {
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dependencies": [
+        "minimatch",
+        "minipass",
+        "path-scurry"
+      ]
+    },
+    "happy-dom@20.9.0": {
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dependencies": [
+        "@types/node@25.6.0",
+        "@types/whatwg-mimetype",
+        "@types/ws",
+        "entities@7.0.1",
+        "whatwg-mimetype@3.0.0",
+        "ws"
+      ]
+    },
+    "html-encoding-sniffer@4.0.0": {
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dependencies": [
+        "whatwg-encoding"
+      ]
+    },
+    "http-proxy-agent@7.0.2": {
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dependencies": [
+        "agent-base",
+        "debug"
+      ]
+    },
+    "https-proxy-agent@7.0.6": {
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": [
+        "agent-base",
+        "debug"
+      ]
+    },
+    "iconv-lite@0.6.3": {
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": [
+        "safer-buffer"
+      ]
+    },
+    "is-potential-custom-element-name@1.0.1": {
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
+    "isexe@2.0.0": {
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "js-tokens@4.0.0": {
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "jsdom@26.1.0": {
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dependencies": [
+        "cssstyle",
+        "data-urls",
+        "decimal.js",
+        "html-encoding-sniffer",
+        "http-proxy-agent",
+        "https-proxy-agent",
+        "is-potential-custom-element-name",
+        "nwsapi",
+        "parse5",
+        "rrweb-cssom",
+        "saxes",
+        "symbol-tree",
+        "tough-cookie",
+        "w3c-xmlserializer",
+        "webidl-conversions",
+        "whatwg-encoding",
+        "whatwg-mimetype@4.0.0",
+        "whatwg-url",
+        "ws",
+        "xml-name-validator"
+      ]
+    },
+    "lru-cache@10.4.3": {
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
+    "lru-cache@11.3.5": {
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="
+    },
+    "lz-string@1.5.0": {
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "bin": true
+    },
+    "minimatch@10.2.5": {
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dependencies": [
+        "brace-expansion"
+      ]
+    },
+    "minipass@7.1.3": {
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "nwsapi@2.2.23": {
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="
+    },
+    "package-json-from-dist@1.0.1": {
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
+    },
+    "parse5@7.3.0": {
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dependencies": [
+        "entities@6.0.1"
+      ]
+    },
+    "path-key@3.1.1": {
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-scurry@2.0.2": {
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dependencies": [
+        "lru-cache@11.3.5",
+        "minipass"
+      ]
+    },
+    "picocolors@1.1.1": {
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "poku@4.3.0": {
+      "integrity": "sha512-s6xHA93lzirvScBuW5UxUAbx4Cw6C/5MEMTe/27jTtLkDmIsWNpUH2CiMbSOKMxLGj7C3JoM2zfacu3kCrlk3Q==",
+      "bin": true
+    },
+    "pretty-format@27.5.1": {
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dependencies": [
+        "ansi-regex",
+        "ansi-styles",
+        "react-is"
+      ]
+    },
+    "punycode@2.3.1": {
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+    },
+    "react-is@17.0.2": {
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "resolve-pkg-maps@1.0.0": {
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="
+    },
+    "rimraf@6.1.3": {
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dependencies": [
+        "glob",
+        "package-json-from-dist"
+      ],
+      "bin": true
+    },
+    "rrweb-cssom@0.8.0": {
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="
+    },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "saxes@6.0.0": {
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dependencies": [
+        "xmlchars"
+      ]
+    },
+    "shebang-command@2.0.0": {
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": [
+        "shebang-regex"
+      ]
+    },
+    "shebang-regex@3.0.0": {
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "symbol-tree@3.2.4": {
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "tldts-core@6.1.86": {
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="
+    },
+    "tldts@6.1.86": {
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dependencies": [
+        "tldts-core"
+      ],
+      "bin": true
+    },
+    "tough-cookie@5.1.2": {
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dependencies": [
+        "tldts"
+      ]
+    },
+    "tr46@5.1.1": {
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dependencies": [
+        "punycode"
+      ]
+    },
+    "tsx@4.21.0": {
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dependencies": [
+        "esbuild",
+        "get-tsconfig"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "bin": true
+    },
+    "typescript@6.0.3": {
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "bin": true
+    },
+    "undici-types@6.21.0": {
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    },
+    "undici-types@7.19.2": {
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="
+    },
+    "undici-types@7.25.0": {
+      "integrity": "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA=="
+    },
+    "w3c-xmlserializer@5.0.0": {
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dependencies": [
+        "xml-name-validator"
+      ]
+    },
+    "webidl-conversions@7.0.0": {
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+    },
+    "whatwg-encoding@3.1.1": {
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dependencies": [
+        "iconv-lite"
+      ],
+      "deprecated": true
+    },
+    "whatwg-mimetype@3.0.0": {
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
+    },
+    "whatwg-mimetype@4.0.0": {
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="
+    },
+    "whatwg-url@14.2.0": {
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dependencies": [
+        "tr46",
+        "webidl-conversions"
+      ]
+    },
+    "which@2.0.2": {
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": [
+        "isexe"
+      ],
+      "bin": true
+    },
+    "ws@8.20.0": {
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
+    },
+    "xml-name-validator@5.0.0": {
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="
+    },
+    "xmlchars@2.2.0": {
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    }
+  },
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:@happy-dom/global-registrator@^20.8.9",
+        "npm:@testing-library/dom@^10.4.1",
+        "npm:@types/jsdom@^28.0.1",
+        "npm:@types/node@^25.5.0",
+        "npm:cross-env@^10.1.0",
+        "npm:happy-dom@^20.8.9",
+        "npm:jsdom@^26.1.0",
+        "npm:poku@^4.3.0",
+        "npm:rimraf@^6.0.1",
+        "npm:tsx@^4.21.0",
+        "npm:typescript@^6.0.2"
+      ]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
+        "@pokujs/scope-hooks": "file:../scope-hooks",
         "@testing-library/dom": "^10.4.1"
       },
       "devDependencies": {
@@ -18,7 +19,7 @@
         "cross-env": "^10.1.0",
         "happy-dom": "^20.8.9",
         "jsdom": "^26.1.0",
-        "poku": "4.2.0",
+        "poku": "^4.3.0",
         "rimraf": "^6.0.1",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2"
@@ -30,15 +31,11 @@
         "typescript": ">=6.x.x"
       },
       "peerDependencies": {
-        "@happy-dom/global-registrator": ">=20",
         "happy-dom": ">=20",
         "jsdom": ">=22",
         "poku": ">=4.1.0"
       },
       "peerDependenciesMeta": {
-        "@happy-dom/global-registrator": {
-          "optional": true
-        },
         "happy-dom": {
           "optional": true
         },
@@ -47,10 +44,950 @@
         }
       }
     },
+    "../scope-hooks": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
+        "@types/node": "^25.5.0",
+        "poku": "4.2.2-canary.24d7783d",
+        "prettier": "^3.6.2",
+        "rimraf": "^6.0.1",
+        "tsx": "^4.21.0",
+        "typescript": "^6.0.2"
+      },
+      "engines": {
+        "bun": ">=1.x.x",
+        "deno": ">=2.x.x",
+        "node": ">=20.x.x",
+        "typescript": ">=6.x.x"
+      },
+      "peerDependencies": {
+        "poku": ">=4.2.2-canary.24d7783d"
+      }
+    },
+    "../scope-hooks/node_modules/.deno": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0/node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0/node_modules/@babel/helper-validator-identifier": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+helper-validator-identifier@7.28.5/node_modules/@babel/helper-validator-identifier",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0/node_modules/js-tokens": {
+      "resolved": "../scope-hooks/node_modules/.deno/js-tokens@4.0.0/node_modules/js-tokens",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0/node_modules/picocolors": {
+      "resolved": "../scope-hooks/node_modules/.deno/picocolors@1.1.1/node_modules/picocolors",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@babel/parser": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2/node_modules/@babel/parser",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@babel/types": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/types",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@jridgewell/gen-mapping": {
+      "resolved": "../scope-hooks/node_modules/.deno/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/gen-mapping",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@jridgewell/trace-mapping": {
+      "resolved": "../scope-hooks/node_modules/.deno/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/trace-mapping",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/jsesc": {
+      "resolved": "../scope-hooks/node_modules/.deno/jsesc@3.1.0/node_modules/jsesc",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+helper-globals@7.28.0/node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "globals": "^16.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@babel+helper-string-parser@7.27.1/node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "charcodes": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@babel+helper-validator-identifier@7.28.5/node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@unicode/unicode-17.0.0": "^1.6.10",
+        "charcodes": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2/node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2/node_modules/@babel/types": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/types",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+template@7.28.6": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+template@7.28.6/node_modules/@babel/code-frame": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0/node_modules/@babel/code-frame",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+template@7.28.6/node_modules/@babel/parser": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2/node_modules/@babel/parser",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+template@7.28.6/node_modules/@babel/template": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@babel+template@7.28.6/node_modules/@babel/types": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/types",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/code-frame": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0/node_modules/@babel/code-frame",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/generator": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@babel/generator",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/helper-globals": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+helper-globals@7.28.0/node_modules/@babel/helper-globals",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/parser": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2/node_modules/@babel/parser",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/template": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+template@7.28.6/node_modules/@babel/template",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/types": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/types",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/debug": {
+      "resolved": "../scope-hooks/node_modules/.deno/debug@4.4.3/node_modules/debug",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+types@7.29.0": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/helper-string-parser": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+helper-string-parser@7.27.1/node_modules/@babel/helper-string-parser",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/helper-validator-identifier": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+helper-validator-identifier@7.28.5/node_modules/@babel/helper-validator-identifier",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/types": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@esbuild+darwin-arm64@0.27.7/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/@babel/generator": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@babel/generator",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/@babel/parser": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2/node_modules/@babel/parser",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/@babel/traverse": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/traverse",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/@babel/types": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/types",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/@ianvs/prettier-plugin-sort-imports": {
+      "version": "4.7.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/generator": "^7.26.2",
+        "@babel/parser": "^7.26.2",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.26.0",
+        "semver": "^7.5.2"
+      },
+      "peerDependencies": {
+        "@prettier/plugin-oxc": "^0.0.4 || ^0.1.0",
+        "@vue/compiler-sfc": "2.7.x || 3.x",
+        "content-tag": "^4.0.0",
+        "prettier": "2 || 3 || ^4.0.0-0",
+        "prettier-plugin-ember-template-tag": "^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
+        "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "content-tag": {
+          "optional": true
+        },
+        "prettier-plugin-ember-template-tag": {
+          "optional": true
+        }
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/prettier": {
+      "resolved": "../scope-hooks/node_modules/.deno/prettier@3.8.1/node_modules/prettier",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/semver": {
+      "resolved": "../scope-hooks/node_modules/.deno/semver@7.7.4/node_modules/semver",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@jridgewell+gen-mapping@0.3.13": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec": {
+      "resolved": "../scope-hooks/node_modules/.deno/@jridgewell+sourcemap-codec@1.5.5/node_modules/@jridgewell/sourcemap-codec",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping": {
+      "resolved": "../scope-hooks/node_modules/.deno/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/trace-mapping",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@jridgewell/resolve-uri-latest": "npm:@jridgewell/resolve-uri@*",
+        "@rollup/plugin-typescript": "8.3.0",
+        "@typescript-eslint/eslint-plugin": "5.10.0",
+        "@typescript-eslint/parser": "5.10.0",
+        "c8": "7.11.0",
+        "eslint": "8.7.0",
+        "eslint-config-prettier": "8.3.0",
+        "mocha": "9.2.0",
+        "npm-run-all": "4.1.5",
+        "prettier": "2.5.1",
+        "rollup": "2.66.0",
+        "typescript": "4.5.5"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@jridgewell+sourcemap-codec@1.5.5/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../scope-hooks/node_modules/.deno/@jridgewell+trace-mapping@0.3.31": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/resolve-uri": {
+      "resolved": "../scope-hooks/node_modules/.deno/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec": {
+      "resolved": "../scope-hooks/node_modules/.deno/@jridgewell+sourcemap-codec@1.5.5/node_modules/@jridgewell/sourcemap-codec",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@types+node@25.5.2": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/@types+node@25.5.2/node_modules/@types/node": {
+      "version": "25.5.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/@types+node@25.5.2/node_modules/undici-types": {
+      "resolved": "../scope-hooks/node_modules/.deno/undici-types@7.18.2/node_modules/undici-types",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/balanced-match@4.0.4/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@types/brace-expansion": "^1.1.2",
+        "@types/node": "^25.2.1",
+        "mkdirp": "^3.0.1",
+        "prettier": "^3.3.2",
+        "tap": "^21.6.2",
+        "tshy": "^3.0.2",
+        "typedoc": "^0.28.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/brace-expansion@5.0.5": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/brace-expansion@5.0.5/node_modules/balanced-match": {
+      "resolved": "../scope-hooks/node_modules/.deno/balanced-match@4.0.4/node_modules/balanced-match",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/brace-expansion@5.0.5/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/debug@4.4.3": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/debug@4.4.3/node_modules/debug": {
+      "version": "4.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "../scope-hooks/node_modules/.deno/debug@4.4.3/node_modules/ms": {
+      "resolved": "../scope-hooks/node_modules/.deno/ms@2.1.3/node_modules/ms",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/esbuild@0.27.7": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/esbuild@0.27.7/node_modules/@esbuild/darwin-arm64": {
+      "resolved": "../scope-hooks/node_modules/.deno/@esbuild+darwin-arm64@0.27.7/node_modules/@esbuild/darwin-arm64",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/esbuild@0.27.7/node_modules/esbuild": {
+      "version": "0.27.7",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/fsevents@2.3.3/node_modules/fsevents": {
+      "version": "2.3.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "devDependencies": {
+        "node-gyp": "^9.4.0"
+      },
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/get-tsconfig@4.13.7": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/get-tsconfig@4.13.7/node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/get-tsconfig@4.13.7/node_modules/resolve-pkg-maps": {
+      "resolved": "../scope-hooks/node_modules/.deno/resolve-pkg-maps@1.0.0/node_modules/resolve-pkg-maps",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/glob@13.0.6": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/glob@13.0.6/node_modules/glob": {
+      "version": "13.0.6",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/glob@13.0.6/node_modules/minimatch": {
+      "resolved": "../scope-hooks/node_modules/.deno/minimatch@10.2.5/node_modules/minimatch",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/glob@13.0.6/node_modules/minipass": {
+      "resolved": "../scope-hooks/node_modules/.deno/minipass@7.1.3/node_modules/minipass",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/glob@13.0.6/node_modules/path-scurry": {
+      "resolved": "../scope-hooks/node_modules/.deno/path-scurry@2.0.2/node_modules/path-scurry",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/js-tokens@4.0.0/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "coffeescript": "2.1.1",
+        "esprima": "4.0.0",
+        "everything.js": "1.0.3",
+        "mocha": "5.0.0"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/jsesc@3.1.0/node_modules/jsesc": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.6",
+        "grunt": "^0.4.5",
+        "grunt-cli": "^1.3.2",
+        "grunt-template": "^0.2.3",
+        "istanbul": "^0.4.2",
+        "mocha": "^5.2.0",
+        "regenerate": "^1.3.0",
+        "requirejs": "^2.1.22",
+        "unicode-13.0.0": "0.8.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/lru-cache@11.3.3/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "esbuild": "^0.25.9",
+        "marked": "^4.2.12",
+        "mkdirp": "^3.0.1",
+        "oxlint": "^1.58.0",
+        "oxlint-tsgolint": "^0.19.0",
+        "prettier": "^3.8.1",
+        "tap": "^21.6.3",
+        "tshy": "^4.1.1",
+        "typedoc": "^0.28.18"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/minimatch@10.2.5": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/minimatch@10.2.5/node_modules/brace-expansion": {
+      "resolved": "../scope-hooks/node_modules/.deno/brace-expansion@5.0.5/node_modules/brace-expansion",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/minimatch@10.2.5/node_modules/minimatch": {
+      "version": "10.2.5",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/minipass@7.1.3/node_modules/minipass": {
+      "version": "7.1.3",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "devDependencies": {
+        "@types/end-of-stream": "^1.4.2",
+        "@types/node": "^25.2.3",
+        "end-of-stream": "^1.4.0",
+        "node-abort-controller": "^3.1.1",
+        "prettier": "^3.8.1",
+        "tap": "^21.6.1",
+        "through2": "^2.0.3",
+        "tshy": "^3.3.2",
+        "typedoc": "^0.28.17"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/ms@2.1.3/node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "4.18.2",
+        "expect.js": "0.3.1",
+        "husky": "0.14.3",
+        "lint-staged": "5.0.0",
+        "mocha": "4.0.1",
+        "prettier": "2.0.5"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/node_modules/@babel/code-frame": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0/node_modules/@babel/code-frame",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/node_modules/@babel/generator": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@babel/generator",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/node_modules/@babel/helper-string-parser": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+helper-string-parser@7.27.1/node_modules/@babel/helper-string-parser",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/node_modules/@babel/helper-validator-identifier": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+helper-validator-identifier@7.28.5/node_modules/@babel/helper-validator-identifier",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/node_modules/@babel/parser": {
+      "resolved": "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2/node_modules/@babel/parser",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/node_modules/@jridgewell/sourcemap-codec": {
+      "resolved": "../scope-hooks/node_modules/.deno/@jridgewell+sourcemap-codec@1.5.5/node_modules/@jridgewell/sourcemap-codec",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/node_modules/esbuild": {
+      "resolved": "../scope-hooks/node_modules/.deno/esbuild@0.27.7/node_modules/esbuild",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/node_modules/glob": {
+      "resolved": "../scope-hooks/node_modules/.deno/glob@13.0.6/node_modules/glob",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/node_modules/ms": {
+      "resolved": "../scope-hooks/node_modules/.deno/ms@2.1.3/node_modules/ms",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/node_modules/picocolors": {
+      "resolved": "../scope-hooks/node_modules/.deno/picocolors@1.1.1/node_modules/picocolors",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/package-json-from-dist@1.0.1/node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "devDependencies": {
+        "@types/node": "^20.12.12",
+        "prettier": "^3.2.5",
+        "tap": "^18.5.3",
+        "tshy": "^1.14.0",
+        "typedoc": "^0.24.8",
+        "typescript": "^5.1.6"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/path-scurry@2.0.2": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/path-scurry@2.0.2/node_modules/lru-cache": {
+      "resolved": "../scope-hooks/node_modules/.deno/lru-cache@11.3.3/node_modules/lru-cache",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/path-scurry@2.0.2/node_modules/minipass": {
+      "resolved": "../scope-hooks/node_modules/.deno/minipass@7.1.3/node_modules/minipass",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/path-scurry@2.0.2/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/picocolors@1.1.1/node_modules/picocolors": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../scope-hooks/node_modules/.deno/poku@4.2.2-canary.24d7783d/node_modules/poku": {
+      "version": "4.2.2-canary.24d7783d",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "poku": "lib/bin/index.js"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.10",
+        "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
+        "@pokujs/c8": "^1.2.0",
+        "@pokujs/docker": "^1.0.0",
+        "@types/node": "^25.5.0",
+        "concurrently": "^9.2.1",
+        "jsonc.min": "^1.1.2",
+        "monocart-coverage-reports": "^2.12.9",
+        "packages-update": "^2.0.0",
+        "prettier": "^3.8.1",
+        "tsx": "^4.21.0",
+        "typescript": "^6.0.2"
+      },
+      "engines": {
+        "bun": ">=1.x.x",
+        "deno": ">=2.x.x",
+        "node": ">=16.x.x",
+        "typescript": ">=5.x.x"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/prettier@3.8.1/node_modules/prettier": {
+      "version": "3.8.1",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/resolve-pkg-maps@1.0.0/node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/rimraf@6.1.3": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/rimraf@6.1.3/node_modules/glob": {
+      "resolved": "../scope-hooks/node_modules/.deno/glob@13.0.6/node_modules/glob",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/rimraf@6.1.3/node_modules/package-json-from-dist": {
+      "resolved": "../scope-hooks/node_modules/.deno/package-json-from-dist@1.0.1/node_modules/package-json-from-dist",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/rimraf@6.1.3/node_modules/rimraf": {
+      "version": "6.1.3",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/semver@7.7.4/node_modules/semver": {
+      "version": "7.7.4",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "devDependencies": {
+        "@npmcli/eslint-config": "^6.0.0",
+        "@npmcli/template-oss": "4.29.0",
+        "benchmark": "^2.1.4",
+        "tap": "^16.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/tsx@4.21.0": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/tsx@4.21.0/node_modules/esbuild": {
+      "resolved": "../scope-hooks/node_modules/.deno/esbuild@0.27.7/node_modules/esbuild",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/tsx@4.21.0/node_modules/fsevents": {
+      "resolved": "../scope-hooks/node_modules/.deno/fsevents@2.3.3/node_modules/fsevents",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/tsx@4.21.0/node_modules/get-tsconfig": {
+      "resolved": "../scope-hooks/node_modules/.deno/get-tsconfig@4.13.7/node_modules/get-tsconfig",
+      "link": true
+    },
+    "../scope-hooks/node_modules/.deno/tsx@4.21.0/node_modules/tsx": {
+      "version": "4.21.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/typescript@6.0.2": {
+      "dev": true
+    },
+    "../scope-hooks/node_modules/.deno/typescript@6.0.2/node_modules/typescript": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "../scope-hooks/node_modules/.deno/undici-types@7.18.2/node_modules/undici-types": {
+      "version": "7.18.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../scope-hooks/node_modules/@ianvs/prettier-plugin-sort-imports": {
+      "resolved": "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/@ianvs/prettier-plugin-sort-imports",
+      "link": true
+    },
+    "../scope-hooks/node_modules/@types/node": {
+      "resolved": "../scope-hooks/node_modules/.deno/@types+node@25.5.2/node_modules/@types/node",
+      "link": true
+    },
+    "../scope-hooks/node_modules/poku": {
+      "resolved": "../scope-hooks/node_modules/.deno/poku@4.2.2-canary.24d7783d/node_modules/poku",
+      "link": true
+    },
+    "../scope-hooks/node_modules/prettier": {
+      "resolved": "../scope-hooks/node_modules/.deno/prettier@3.8.1/node_modules/prettier",
+      "link": true
+    },
+    "../scope-hooks/node_modules/rimraf": {
+      "resolved": "../scope-hooks/node_modules/.deno/rimraf@6.1.3/node_modules/rimraf",
+      "link": true
+    },
+    "../scope-hooks/node_modules/tsx": {
+      "resolved": "../scope-hooks/node_modules/.deno/tsx@4.21.0/node_modules/tsx",
+      "link": true
+    },
+    "../scope-hooks/node_modules/typescript": {
+      "resolved": "../scope-hooks/node_modules/.deno/typescript@6.0.2/node_modules/typescript",
+      "link": true
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -63,8 +1000,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -77,8 +1012,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -86,8 +1019,6 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -95,8 +1026,6 @@
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
       "dev": true,
       "funding": [
         {
@@ -115,8 +1044,6 @@
     },
     "node_modules/@csstools/css-calc": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
       "dev": true,
       "funding": [
         {
@@ -139,8 +1066,6 @@
     },
     "node_modules/@csstools/css-color-parser": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
       "dev": true,
       "funding": [
         {
@@ -167,8 +1092,6 @@
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
       "dev": true,
       "funding": [
         {
@@ -190,8 +1113,6 @@
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
       "dev": true,
       "funding": [
         {
@@ -210,83 +1131,11 @@
     },
     "node_modules/@epic-web/invariant": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
-      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -295,363 +1144,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -659,8 +1151,6 @@
     },
     "node_modules/@happy-dom/global-registrator": {
       "version": "20.8.9",
-      "resolved": "https://registry.npmjs.org/@happy-dom/global-registrator/-/global-registrator-20.8.9.tgz",
-      "integrity": "sha512-DtZeRRHY9A/bisTJziUBBPrdnPui7+R185G/hzi6/Boymhqh7/wi53AY+IvQHS1+7OPaqfO/1XNpngNwthLz+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -671,10 +1161,12 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@pokujs/scope-hooks": {
+      "resolved": "../scope-hooks",
+      "link": true
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -692,14 +1184,10 @@
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "license": "MIT"
     },
     "node_modules/@types/jsdom": {
       "version": "28.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.1.tgz",
-      "integrity": "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -711,8 +1199,6 @@
     },
     "node_modules/@types/node": {
       "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -721,29 +1207,21 @@
     },
     "node_modules/@types/node/node_modules/undici-types": {
       "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
-      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -752,8 +1230,6 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -762,8 +1238,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -771,8 +1245,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -783,8 +1255,6 @@
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -792,8 +1262,6 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -802,8 +1270,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -815,8 +1281,6 @@
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
-      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -833,8 +1297,6 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -848,8 +1310,6 @@
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
-      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -862,8 +1322,6 @@
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -876,8 +1334,6 @@
     },
     "node_modules/data-urls/node_modules/whatwg-mimetype": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -886,8 +1342,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -904,15 +1358,11 @@
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -920,14 +1370,10 @@
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "license": "MIT"
     },
     "node_modules/entities": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -939,8 +1385,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -981,10 +1425,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -996,8 +1437,6 @@
     },
     "node_modules/get-tsconfig": {
       "version": "4.13.7",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1009,8 +1448,6 @@
     },
     "node_modules/glob": {
       "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1027,8 +1464,6 @@
     },
     "node_modules/happy-dom": {
       "version": "20.8.9",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
-      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1045,8 +1480,6 @@
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1058,8 +1491,6 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1072,8 +1503,6 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1086,8 +1515,6 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1099,28 +1526,20 @@
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1159,8 +1578,6 @@
     },
     "node_modules/jsdom/node_modules/whatwg-mimetype": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1169,15 +1586,11 @@
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -1185,8 +1598,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1201,8 +1612,6 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1211,29 +1620,21 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nwsapi": {
       "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1245,8 +1646,6 @@
     },
     "node_modules/parse5/node_modules/entities": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -1258,8 +1657,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1268,8 +1665,6 @@
     },
     "node_modules/path-scurry": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1285,8 +1680,6 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1295,14 +1688,12 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/poku": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/poku/-/poku-4.2.0.tgz",
-      "integrity": "sha512-GygMGFGgEJ9kfs6Z+QPg/ODs9OF3oGHN8+hYIxtBox3pwYISO+Vu660vH1e+YzjpGoaoy2o5y6YwE1tX5yZx3Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/poku/-/poku-4.3.0.tgz",
+      "integrity": "sha512-s6xHA93lzirvScBuW5UxUAbx4Cw6C/5MEMTe/27jTtLkDmIsWNpUH2CiMbSOKMxLGj7C3JoM2zfacu3kCrlk3Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1321,8 +1712,6 @@
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1",
@@ -1335,8 +1724,6 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1345,14 +1732,10 @@
     },
     "node_modules/react-is": {
       "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1361,8 +1744,6 @@
     },
     "node_modules/rimraf": {
       "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
-      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1381,22 +1762,16 @@
     },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1408,8 +1783,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1421,8 +1794,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1431,15 +1802,11 @@
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tldts": {
       "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1451,15 +1818,11 @@
     },
     "node_modules/tldts-core": {
       "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1471,8 +1834,6 @@
     },
     "node_modules/tr46": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1484,8 +1845,6 @@
     },
     "node_modules/tsx": {
       "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1504,8 +1863,6 @@
     },
     "node_modules/typescript": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1518,15 +1875,11 @@
     },
     "node_modules/undici-types": {
       "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.7.tgz",
-      "integrity": "sha512-XA+gOBkzYD3C74sZowtCLTpgtaCdqZhqCvR6y9LXvrKTt/IVU6bz49T4D+BPi475scshCCkb0IklJRw6T1ZlgQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
-      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1538,8 +1891,6 @@
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -1548,9 +1899,6 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1562,8 +1910,6 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1572,8 +1918,6 @@
     },
     "node_modules/whatwg-url": {
       "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1586,8 +1930,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1602,8 +1944,6 @@
     },
     "node_modules/ws": {
       "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1624,8 +1964,6 @@
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1634,8 +1972,6 @@
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@pokujs/scope-hooks": "file:../scope-hooks",
+        "@pokujs/scope-hooks": "^1.1.0",
         "@testing-library/dom": "^10.4.1"
       },
       "devDependencies": {
@@ -42,28 +42,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "../scope-hooks": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "devDependencies": {
-        "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
-        "@types/node": "^25.5.0",
-        "poku": "4.2.2-canary.24d7783d",
-        "prettier": "^3.6.2",
-        "rimraf": "^6.0.1",
-        "tsx": "^4.21.0",
-        "typescript": "^6.0.2"
-      },
-      "engines": {
-        "bun": ">=1.x.x",
-        "deno": ">=2.x.x",
-        "node": ">=20.x.x",
-        "typescript": ">=6.x.x"
-      },
-      "peerDependencies": {
-        "poku": ">=4.2.2-canary.24d7783d"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -691,8 +669,19 @@
       }
     },
     "node_modules/@pokujs/scope-hooks": {
-      "resolved": "../scope-hooks",
-      "link": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pokujs/scope-hooks/-/scope-hooks-1.1.0.tgz",
+      "integrity": "sha512-EhUy0aP4k+mMoHxd6eK+Cjuo5YFcpSKfySgT/1+6u7D3UD37JKAbb8cAvnyzhLi+Vfb4y9CQgcyiHksGYtGMZw==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.x.x",
+        "deno": ">=2.x.x",
+        "node": ">=20.x.x",
+        "typescript": ">=6.x.x"
+      },
+      "peerDependencies": {
+        "poku": ">=4.3.0"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -1326,7 +1315,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/poku/-/poku-4.3.0.tgz",
       "integrity": "sha512-s6xHA93lzirvScBuW5UxUAbx4Cw6C/5MEMTe/27jTtLkDmIsWNpUH2CiMbSOKMxLGj7C3JoM2zfacu3kCrlk3Q==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "poku": "lib/bin/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,893 +66,10 @@
         "poku": ">=4.2.2-canary.24d7783d"
       }
     },
-    "../scope-hooks/node_modules/.deno": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0/node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0/node_modules/@babel/helper-validator-identifier": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+helper-validator-identifier@7.28.5/node_modules/@babel/helper-validator-identifier",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0/node_modules/js-tokens": {
-      "resolved": "../scope-hooks/node_modules/.deno/js-tokens@4.0.0/node_modules/js-tokens",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0/node_modules/picocolors": {
-      "resolved": "../scope-hooks/node_modules/.deno/picocolors@1.1.1/node_modules/picocolors",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@babel/parser": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2/node_modules/@babel/parser",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@babel/types": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/types",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@jridgewell/gen-mapping": {
-      "resolved": "../scope-hooks/node_modules/.deno/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/gen-mapping",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@jridgewell/trace-mapping": {
-      "resolved": "../scope-hooks/node_modules/.deno/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/trace-mapping",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/jsesc": {
-      "resolved": "../scope-hooks/node_modules/.deno/jsesc@3.1.0/node_modules/jsesc",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+helper-globals@7.28.0/node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "dev": true,
-      "license": "MIT",
-      "devDependencies": {
-        "globals": "^16.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@babel+helper-string-parser@7.27.1/node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "dev": true,
-      "license": "MIT",
-      "devDependencies": {
-        "charcodes": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@babel+helper-validator-identifier@7.28.5/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "dev": true,
-      "license": "MIT",
-      "devDependencies": {
-        "@unicode/unicode-17.0.0": "^1.6.10",
-        "charcodes": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2/node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2/node_modules/@babel/types": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/types",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+template@7.28.6": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+template@7.28.6/node_modules/@babel/code-frame": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0/node_modules/@babel/code-frame",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+template@7.28.6/node_modules/@babel/parser": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2/node_modules/@babel/parser",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+template@7.28.6/node_modules/@babel/template": {
-      "version": "7.28.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@babel+template@7.28.6/node_modules/@babel/types": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/types",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/code-frame": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0/node_modules/@babel/code-frame",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/generator": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@babel/generator",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/helper-globals": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+helper-globals@7.28.0/node_modules/@babel/helper-globals",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/parser": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2/node_modules/@babel/parser",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/template": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+template@7.28.6/node_modules/@babel/template",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/types": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/types",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/debug": {
-      "resolved": "../scope-hooks/node_modules/.deno/debug@4.4.3/node_modules/debug",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+types@7.29.0": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/helper-string-parser": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+helper-string-parser@7.27.1/node_modules/@babel/helper-string-parser",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/helper-validator-identifier": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+helper-validator-identifier@7.28.5/node_modules/@babel/helper-validator-identifier",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/types": {
-      "version": "7.29.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@esbuild+darwin-arm64@0.27.7/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/@babel/generator": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@babel/generator",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/@babel/parser": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2/node_modules/@babel/parser",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/@babel/traverse": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+traverse@7.29.0/node_modules/@babel/traverse",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/@babel/types": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+types@7.29.0/node_modules/@babel/types",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/@ianvs/prettier-plugin-sort-imports": {
-      "version": "4.7.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/generator": "^7.26.2",
-        "@babel/parser": "^7.26.2",
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.26.0",
-        "semver": "^7.5.2"
-      },
-      "peerDependencies": {
-        "@prettier/plugin-oxc": "^0.0.4 || ^0.1.0",
-        "@vue/compiler-sfc": "2.7.x || 3.x",
-        "content-tag": "^4.0.0",
-        "prettier": "2 || 3 || ^4.0.0-0",
-        "prettier-plugin-ember-template-tag": "^2.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@prettier/plugin-oxc": {
-          "optional": true
-        },
-        "@vue/compiler-sfc": {
-          "optional": true
-        },
-        "content-tag": {
-          "optional": true
-        },
-        "prettier-plugin-ember-template-tag": {
-          "optional": true
-        }
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/prettier": {
-      "resolved": "../scope-hooks/node_modules/.deno/prettier@3.8.1/node_modules/prettier",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/semver": {
-      "resolved": "../scope-hooks/node_modules/.deno/semver@7.7.4/node_modules/semver",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@jridgewell+gen-mapping@0.3.13": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec": {
-      "resolved": "../scope-hooks/node_modules/.deno/@jridgewell+sourcemap-codec@1.5.5/node_modules/@jridgewell/sourcemap-codec",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping": {
-      "resolved": "../scope-hooks/node_modules/.deno/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/trace-mapping",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT",
-      "devDependencies": {
-        "@jridgewell/resolve-uri-latest": "npm:@jridgewell/resolve-uri@*",
-        "@rollup/plugin-typescript": "8.3.0",
-        "@typescript-eslint/eslint-plugin": "5.10.0",
-        "@typescript-eslint/parser": "5.10.0",
-        "c8": "7.11.0",
-        "eslint": "8.7.0",
-        "eslint-config-prettier": "8.3.0",
-        "mocha": "9.2.0",
-        "npm-run-all": "4.1.5",
-        "prettier": "2.5.1",
-        "rollup": "2.66.0",
-        "typescript": "4.5.5"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@jridgewell+sourcemap-codec@1.5.5/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../scope-hooks/node_modules/.deno/@jridgewell+trace-mapping@0.3.31": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/resolve-uri": {
-      "resolved": "../scope-hooks/node_modules/.deno/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec": {
-      "resolved": "../scope-hooks/node_modules/.deno/@jridgewell+sourcemap-codec@1.5.5/node_modules/@jridgewell/sourcemap-codec",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@types+node@25.5.2": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/@types+node@25.5.2/node_modules/@types/node": {
-      "version": "25.5.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/@types+node@25.5.2/node_modules/undici-types": {
-      "resolved": "../scope-hooks/node_modules/.deno/undici-types@7.18.2/node_modules/undici-types",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/balanced-match@4.0.4/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "devDependencies": {
-        "@types/brace-expansion": "^1.1.2",
-        "@types/node": "^25.2.1",
-        "mkdirp": "^3.0.1",
-        "prettier": "^3.3.2",
-        "tap": "^21.6.2",
-        "tshy": "^3.0.2",
-        "typedoc": "^0.28.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/brace-expansion@5.0.5": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/brace-expansion@5.0.5/node_modules/balanced-match": {
-      "resolved": "../scope-hooks/node_modules/.deno/balanced-match@4.0.4/node_modules/balanced-match",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/brace-expansion@5.0.5/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/debug@4.4.3": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/debug@4.4.3/node_modules/debug": {
-      "version": "4.4.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "../scope-hooks/node_modules/.deno/debug@4.4.3/node_modules/ms": {
-      "resolved": "../scope-hooks/node_modules/.deno/ms@2.1.3/node_modules/ms",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/esbuild@0.27.7": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/esbuild@0.27.7/node_modules/@esbuild/darwin-arm64": {
-      "resolved": "../scope-hooks/node_modules/.deno/@esbuild+darwin-arm64@0.27.7/node_modules/@esbuild/darwin-arm64",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/esbuild@0.27.7/node_modules/esbuild": {
-      "version": "0.27.7",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/fsevents@2.3.3/node_modules/fsevents": {
-      "version": "2.3.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "devDependencies": {
-        "node-gyp": "^9.4.0"
-      },
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/get-tsconfig@4.13.7": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/get-tsconfig@4.13.7/node_modules/get-tsconfig": {
-      "version": "4.13.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/get-tsconfig@4.13.7/node_modules/resolve-pkg-maps": {
-      "resolved": "../scope-hooks/node_modules/.deno/resolve-pkg-maps@1.0.0/node_modules/resolve-pkg-maps",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/glob@13.0.6": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/glob@13.0.6/node_modules/glob": {
-      "version": "13.0.6",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/glob@13.0.6/node_modules/minimatch": {
-      "resolved": "../scope-hooks/node_modules/.deno/minimatch@10.2.5/node_modules/minimatch",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/glob@13.0.6/node_modules/minipass": {
-      "resolved": "../scope-hooks/node_modules/.deno/minipass@7.1.3/node_modules/minipass",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/glob@13.0.6/node_modules/path-scurry": {
-      "resolved": "../scope-hooks/node_modules/.deno/path-scurry@2.0.2/node_modules/path-scurry",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/js-tokens@4.0.0/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "devDependencies": {
-        "coffeescript": "2.1.1",
-        "esprima": "4.0.0",
-        "everything.js": "1.0.3",
-        "mocha": "5.0.0"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/jsesc@3.1.0/node_modules/jsesc": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "devDependencies": {
-        "coveralls": "^2.11.6",
-        "grunt": "^0.4.5",
-        "grunt-cli": "^1.3.2",
-        "grunt-template": "^0.2.3",
-        "istanbul": "^0.4.2",
-        "mocha": "^5.2.0",
-        "regenerate": "^1.3.0",
-        "requirejs": "^2.1.22",
-        "unicode-13.0.0": "0.8.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/lru-cache@11.3.3/node_modules/lru-cache": {
-      "version": "11.3.3",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "devDependencies": {
-        "benchmark": "^2.1.4",
-        "esbuild": "^0.25.9",
-        "marked": "^4.2.12",
-        "mkdirp": "^3.0.1",
-        "oxlint": "^1.58.0",
-        "oxlint-tsgolint": "^0.19.0",
-        "prettier": "^3.8.1",
-        "tap": "^21.6.3",
-        "tshy": "^4.1.1",
-        "typedoc": "^0.28.18"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/minimatch@10.2.5": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/minimatch@10.2.5/node_modules/brace-expansion": {
-      "resolved": "../scope-hooks/node_modules/.deno/brace-expansion@5.0.5/node_modules/brace-expansion",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/minimatch@10.2.5/node_modules/minimatch": {
-      "version": "10.2.5",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/minipass@7.1.3/node_modules/minipass": {
-      "version": "7.1.3",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "devDependencies": {
-        "@types/end-of-stream": "^1.4.2",
-        "@types/node": "^25.2.3",
-        "end-of-stream": "^1.4.0",
-        "node-abort-controller": "^3.1.1",
-        "prettier": "^3.8.1",
-        "tap": "^21.6.1",
-        "through2": "^2.0.3",
-        "tshy": "^3.3.2",
-        "typedoc": "^0.28.17"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/ms@2.1.3/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "devDependencies": {
-        "eslint": "4.18.2",
-        "expect.js": "0.3.1",
-        "husky": "0.14.3",
-        "lint-staged": "5.0.0",
-        "mocha": "4.0.1",
-        "prettier": "2.0.5"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/node_modules/esbuild": {
-      "resolved": "../scope-hooks/node_modules/.deno/esbuild@0.27.7/node_modules/esbuild",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/package-json-from-dist@1.0.1/node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "devDependencies": {
-        "@types/node": "^20.12.12",
-        "prettier": "^3.2.5",
-        "tap": "^18.5.3",
-        "tshy": "^1.14.0",
-        "typedoc": "^0.24.8",
-        "typescript": "^5.1.6"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/path-scurry@2.0.2": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/path-scurry@2.0.2/node_modules/lru-cache": {
-      "resolved": "../scope-hooks/node_modules/.deno/lru-cache@11.3.3/node_modules/lru-cache",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/path-scurry@2.0.2/node_modules/minipass": {
-      "resolved": "../scope-hooks/node_modules/.deno/minipass@7.1.3/node_modules/minipass",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/path-scurry@2.0.2/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/picocolors@1.1.1/node_modules/picocolors": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "ISC"
-    },
-    "../scope-hooks/node_modules/.deno/poku@4.2.2-canary.24d7783d/node_modules/poku": {
-      "version": "4.2.2-canary.24d7783d",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "poku": "lib/bin/index.js"
-      },
-      "devDependencies": {
-        "@biomejs/biome": "^2.4.10",
-        "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
-        "@pokujs/c8": "^1.2.0",
-        "@pokujs/docker": "^1.0.0",
-        "@types/node": "^25.5.0",
-        "concurrently": "^9.2.1",
-        "jsonc.min": "^1.1.2",
-        "monocart-coverage-reports": "^2.12.9",
-        "packages-update": "^2.0.0",
-        "prettier": "^3.8.1",
-        "tsx": "^4.21.0",
-        "typescript": "^6.0.2"
-      },
-      "engines": {
-        "bun": ">=1.x.x",
-        "deno": ">=2.x.x",
-        "node": ">=16.x.x",
-        "typescript": ">=5.x.x"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wellwelwel"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/prettier@3.8.1/node_modules/prettier": {
-      "version": "3.8.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/resolve-pkg-maps@1.0.0/node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/rimraf@6.1.3": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/rimraf@6.1.3/node_modules/glob": {
-      "resolved": "../scope-hooks/node_modules/.deno/glob@13.0.6/node_modules/glob",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/rimraf@6.1.3/node_modules/package-json-from-dist": {
-      "resolved": "../scope-hooks/node_modules/.deno/package-json-from-dist@1.0.1/node_modules/package-json-from-dist",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/rimraf@6.1.3/node_modules/rimraf": {
-      "version": "6.1.3",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "glob": "^13.0.3",
-        "package-json-from-dist": "^1.0.1"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/semver@7.7.4/node_modules/semver": {
-      "version": "7.7.4",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "devDependencies": {
-        "@npmcli/eslint-config": "^6.0.0",
-        "@npmcli/template-oss": "4.29.0",
-        "benchmark": "^2.1.4",
-        "tap": "^16.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/tsx@4.21.0": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/tsx@4.21.0/node_modules/esbuild": {
-      "resolved": "../scope-hooks/node_modules/.deno/esbuild@0.27.7/node_modules/esbuild",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/tsx@4.21.0/node_modules/fsevents": {
-      "resolved": "../scope-hooks/node_modules/.deno/fsevents@2.3.3/node_modules/fsevents",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/tsx@4.21.0/node_modules/get-tsconfig": {
-      "resolved": "../scope-hooks/node_modules/.deno/get-tsconfig@4.13.7/node_modules/get-tsconfig",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/tsx@4.21.0/node_modules/tsx": {
-      "version": "4.21.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/typescript@6.0.2": {
-      "dev": true
-    },
-    "../scope-hooks/node_modules/.deno/typescript@6.0.2/node_modules/typescript": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "../scope-hooks/node_modules/.deno/undici-types@7.18.2/node_modules/undici-types": {
-      "version": "7.18.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../scope-hooks/node_modules/@ianvs/prettier-plugin-sort-imports": {
-      "resolved": "../scope-hooks/node_modules/.deno/@ianvs+prettier-plugin-sort-imports@4.7.1/node_modules/@ianvs/prettier-plugin-sort-imports",
-      "link": true
-    },
-    "../scope-hooks/node_modules/@types/node": {
-      "resolved": "../scope-hooks/node_modules/.deno/@types+node@25.5.2/node_modules/@types/node",
-      "link": true
-    },
-    "../scope-hooks/node_modules/poku": {
-      "resolved": "../scope-hooks/node_modules/.deno/poku@4.2.2-canary.24d7783d/node_modules/poku",
-      "link": true
-    },
-    "../scope-hooks/node_modules/prettier": {
-      "resolved": "../scope-hooks/node_modules/.deno/prettier@3.8.1/node_modules/prettier",
-      "link": true
-    },
-    "../scope-hooks/node_modules/rimraf": {
-      "resolved": "../scope-hooks/node_modules/.deno/rimraf@6.1.3/node_modules/rimraf",
-      "link": true
-    },
-    "../scope-hooks/node_modules/tsx": {
-      "resolved": "../scope-hooks/node_modules/.deno/tsx@4.21.0/node_modules/tsx",
-      "link": true
-    },
-    "../scope-hooks/node_modules/typescript": {
-      "resolved": "../scope-hooks/node_modules/.deno/typescript@6.0.2/node_modules/typescript",
-      "link": true
-    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -965,6 +82,8 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -977,6 +96,8 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -984,6 +105,8 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -991,6 +114,8 @@
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
       "dev": true,
       "funding": [
         {
@@ -1009,6 +134,8 @@
     },
     "node_modules/@csstools/css-calc": {
       "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
       "dev": true,
       "funding": [
         {
@@ -1031,6 +158,8 @@
     },
     "node_modules/@csstools/css-color-parser": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
       "dev": true,
       "funding": [
         {
@@ -1057,6 +186,8 @@
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
       "dev": true,
       "funding": [
         {
@@ -1078,6 +209,8 @@
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
       "dev": true,
       "funding": [
         {
@@ -1096,11 +229,83 @@
     },
     "node_modules/@epic-web/invariant": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -1114,13 +319,372 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@happy-dom/global-registrator": {
-      "version": "20.8.9",
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@happy-dom/global-registrator/-/global-registrator-20.9.0.tgz",
+      "integrity": "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": ">=20.0.0",
-        "happy-dom": "^20.8.9"
+        "happy-dom": "^20.9.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1132,6 +696,8 @@
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -1149,10 +715,14 @@
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "license": "MIT"
     },
     "node_modules/@types/jsdom": {
       "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.1.tgz",
+      "integrity": "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1163,30 +733,40 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/node/node_modules/undici-types": {
-      "version": "7.18.2",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1195,6 +775,8 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1203,6 +785,8 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1210,6 +794,8 @@
     },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1220,6 +806,8 @@
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1227,6 +815,8 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1235,6 +825,8 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1246,6 +838,8 @@
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1262,6 +856,8 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1275,6 +871,8 @@
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1287,6 +885,8 @@
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1299,6 +899,8 @@
     },
     "node_modules/data-urls/node_modules/whatwg-mimetype": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1307,6 +909,8 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1323,11 +927,15 @@
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1335,10 +943,14 @@
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "license": "MIT"
     },
     "node_modules/entities": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -1350,6 +962,8 @@
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1390,7 +1004,10 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1401,7 +1018,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.7",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1413,6 +1032,8 @@
     },
     "node_modules/glob": {
       "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1428,7 +1049,9 @@
       }
     },
     "node_modules/happy-dom": {
-      "version": "20.8.9",
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1445,6 +1068,8 @@
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1456,6 +1081,8 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1468,6 +1095,8 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1480,6 +1109,8 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1491,20 +1122,28 @@
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1543,6 +1182,8 @@
     },
     "node_modules/jsdom/node_modules/whatwg-mimetype": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1551,11 +1192,15 @@
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -1563,6 +1208,8 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1577,6 +1224,8 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1585,21 +1234,29 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nwsapi": {
       "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1611,6 +1268,8 @@
     },
     "node_modules/parse5/node_modules/entities": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -1622,6 +1281,8 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1630,6 +1291,8 @@
     },
     "node_modules/path-scurry": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1644,7 +1307,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.7",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1653,6 +1318,8 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/poku": {
@@ -1677,6 +1344,8 @@
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1",
@@ -1689,6 +1358,8 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1697,10 +1368,14 @@
     },
     "node_modules/react-is": {
       "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1709,6 +1384,8 @@
     },
     "node_modules/rimraf": {
       "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1727,16 +1404,22 @@
     },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1748,6 +1431,8 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1759,6 +1444,8 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1767,11 +1454,15 @@
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tldts": {
       "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1783,11 +1474,15 @@
     },
     "node_modules/tldts-core": {
       "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1799,6 +1494,8 @@
     },
     "node_modules/tr46": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1810,6 +1507,8 @@
     },
     "node_modules/tsx": {
       "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1827,7 +1526,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1839,12 +1540,16 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.7",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.25.0.tgz",
+      "integrity": "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1856,6 +1561,8 @@
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -1864,6 +1571,9 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1875,6 +1585,8 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1883,6 +1595,8 @@
     },
     "node_modules/whatwg-url": {
       "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1895,6 +1609,8 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1909,6 +1625,8 @@
     },
     "node_modules/ws": {
       "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1929,6 +1647,8 @@
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1937,6 +1657,8 @@
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -721,44 +721,8 @@
         "prettier": "2.0.5"
       }
     },
-    "../scope-hooks/node_modules/.deno/node_modules/@babel/code-frame": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+code-frame@7.29.0/node_modules/@babel/code-frame",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/node_modules/@babel/generator": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+generator@7.29.1/node_modules/@babel/generator",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/node_modules/@babel/helper-string-parser": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+helper-string-parser@7.27.1/node_modules/@babel/helper-string-parser",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/node_modules/@babel/helper-validator-identifier": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+helper-validator-identifier@7.28.5/node_modules/@babel/helper-validator-identifier",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/node_modules/@babel/parser": {
-      "resolved": "../scope-hooks/node_modules/.deno/@babel+parser@7.29.2/node_modules/@babel/parser",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/node_modules/@jridgewell/sourcemap-codec": {
-      "resolved": "../scope-hooks/node_modules/.deno/@jridgewell+sourcemap-codec@1.5.5/node_modules/@jridgewell/sourcemap-codec",
-      "link": true
-    },
     "../scope-hooks/node_modules/.deno/node_modules/esbuild": {
       "resolved": "../scope-hooks/node_modules/.deno/esbuild@0.27.7/node_modules/esbuild",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/node_modules/glob": {
-      "resolved": "../scope-hooks/node_modules/.deno/glob@13.0.6/node_modules/glob",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/node_modules/ms": {
-      "resolved": "../scope-hooks/node_modules/.deno/ms@2.1.3/node_modules/ms",
-      "link": true
-    },
-    "../scope-hooks/node_modules/.deno/node_modules/picocolors": {
-      "resolved": "../scope-hooks/node_modules/.deno/picocolors@1.1.1/node_modules/picocolors",
       "link": true
     },
     "../scope-hooks/node_modules/.deno/package-json-from-dist@1.0.1/node_modules/package-json-from-dist": {
@@ -841,6 +805,7 @@
       "version": "3.8.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     }
   },
   "dependencies": {
-    "@pokujs/scope-hooks": "file:../scope-hooks",
+    "@pokujs/scope-hooks": "^1.1.0",
     "@testing-library/dom": "^10.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     }
   },
   "dependencies": {
+    "@pokujs/scope-hooks": "file:../scope-hooks",
     "@testing-library/dom": "^10.4.1"
   },
   "devDependencies": {
@@ -84,7 +85,7 @@
     "cross-env": "^10.1.0",
     "happy-dom": "^20.8.9",
     "jsdom": "^26.1.0",
-    "poku": "4.2.0",
+    "poku": "^4.3.0",
     "rimraf": "^6.0.1",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2"

--- a/src/dom-env.ts
+++ b/src/dom-env.ts
@@ -1,5 +1,6 @@
 import { GlobalWindow } from 'happy-dom';
 import type { RuntimeOptions } from './types.ts';
+import { registerScopeHooks } from './test-scope.ts';
 
 type SetupDomEnvironmentOptions = {
   runtimeOptions: RuntimeOptions;
@@ -30,6 +31,8 @@ const defineGlobal = (key: keyof typeof globalThis, value: unknown) => {
 export const setupHappyDomEnvironment = async (
   options: SetupDomEnvironmentOptions
 ) => {
+  registerScopeHooks();
+
   if (!globalThis.window || !globalThis.document) {
     // Save native event primitives before installing Happy DOM globals.
     // Deno's runtime calls globalThis.dispatchEvent('beforeunload') on exit
@@ -71,6 +74,8 @@ export const setupHappyDomEnvironment = async (
 export const setupJsdomEnvironment = async (
   options: SetupDomEnvironmentOptions
 ) => {
+  registerScopeHooks();
+
   if (!globalThis.window || !globalThis.document) {
     let mod: typeof import('jsdom');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from './plugin-metrics.ts';
 export * from './plugin-factory.ts';
 export * from './dom-env.ts';
 export * from './testing-core.ts';
+export * from './test-scope.ts';

--- a/src/poku-plugins.d.ts
+++ b/src/poku-plugins.d.ts
@@ -7,7 +7,7 @@ declare module 'poku/plugins' {
     createHolder: () => ScopeHookHolder;
     runScoped: (
       holder: ScopeHookHolder,
-      fn: () => Promise<unknown> | unknown
+      fn: (params?: Record<string, unknown>) => Promise<unknown> | unknown
     ) => Promise<void>;
   };
 
@@ -15,7 +15,7 @@ declare module 'poku/plugins' {
     createHolder: () => ScopeHookHolder;
     runScoped: (
       holder: ScopeHookHolder,
-      fn: () => Promise<unknown> | unknown
+      fn: (params?: Record<string, unknown>) => Promise<unknown> | unknown
     ) => Promise<void>;
   };
 }

--- a/src/poku-plugins.d.ts
+++ b/src/poku-plugins.d.ts
@@ -11,11 +11,4 @@ declare module 'poku/plugins' {
     ) => Promise<void>;
   };
 
-  export const composeScopeHooks: (provider: ScopeHookProvider) => {
-    createHolder: () => ScopeHookHolder;
-    runScoped: (
-      holder: ScopeHookHolder,
-      fn: (params?: Record<string, unknown>) => Promise<unknown> | unknown
-    ) => Promise<void>;
-  };
-}
+  }

--- a/src/poku-plugins.d.ts
+++ b/src/poku-plugins.d.ts
@@ -1,3 +1,21 @@
 declare module 'poku/plugins' {
   export const definePlugin: (plugin: any) => any;
+
+  export type ScopeHookHolder = { scope: unknown };
+  export type ScopeHookProvider = {
+    name: string;
+    createHolder: () => ScopeHookHolder;
+    runScoped: (
+      holder: ScopeHookHolder,
+      fn: () => Promise<unknown> | unknown
+    ) => Promise<void>;
+  };
+
+  export const composeScopeHooks: (provider: ScopeHookProvider) => {
+    createHolder: () => ScopeHookHolder;
+    runScoped: (
+      holder: ScopeHookHolder,
+      fn: () => Promise<unknown> | unknown
+    ) => Promise<void>;
+  };
 }

--- a/src/test-scope.ts
+++ b/src/test-scope.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import * as pokuPlugins from 'poku/plugins';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -241,6 +242,28 @@ type GlobalWithScopeHooks = typeof globalThis & {
  * dom-setup-jsdom.ts).  It is idempotent.
  */
 export const registerScopeHooks = (): void => {
+  const compose = (
+    pokuPlugins as {
+      composeScopeHooks?: (provider: {
+        name: string;
+        createHolder: () => { scope: unknown };
+        runScoped: (
+          holder: { scope: unknown },
+          fn: () => Promise<unknown> | unknown
+        ) => Promise<void>;
+      }) => unknown;
+    }
+  ).composeScopeHooks;
+
+  if (typeof compose === 'function') {
+    compose({
+      name: '@pokujs/dom.scope-hooks',
+      createHolder: createLazyHolder,
+      runScoped: (holder, fn) => runScoped(holder as LazyHolder, fn),
+    });
+    return;
+  }
+
   const g = globalThis as GlobalWithScopeHooks;
   if (!g[SCOPE_HOOKS_KEY]) {
     g[SCOPE_HOOKS_KEY] = { createHolder: createLazyHolder, runScoped };

--- a/src/test-scope.ts
+++ b/src/test-scope.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import * as pokuPlugins from 'poku/plugins';
+import { composeScopeHooks } from '@pokujs/scope-hooks';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -242,21 +242,8 @@ type GlobalWithScopeHooks = typeof globalThis & {
  * dom-setup-jsdom.ts).  It is idempotent.
  */
 export const registerScopeHooks = (): void => {
-  const compose = (
-    pokuPlugins as {
-      composeScopeHooks?: (provider: {
-        name: string;
-        createHolder: () => { scope: unknown };
-        runScoped: (
-          holder: { scope: unknown },
-          fn: (params?: Record<string, unknown>) => Promise<unknown> | unknown
-        ) => Promise<void>;
-      }) => unknown;
-    }
-  ).composeScopeHooks;
-
-  if (typeof compose === 'function') {
-    compose({
+  if (typeof composeScopeHooks === 'function') {
+    composeScopeHooks({
       name: '@pokujs/dom.scope-hooks',
       createHolder: createLazyHolder,
       runScoped: (holder, fn) => runScoped(holder as LazyHolder, fn),

--- a/src/test-scope.ts
+++ b/src/test-scope.ts
@@ -249,7 +249,7 @@ export const registerScopeHooks = (): void => {
         createHolder: () => { scope: unknown };
         runScoped: (
           holder: { scope: unknown },
-          fn: () => Promise<unknown> | unknown
+          fn: (params?: Record<string, unknown>) => Promise<unknown> | unknown
         ) => Promise<void>;
       }) => unknown;
     }

--- a/src/test-scope.ts
+++ b/src/test-scope.ts
@@ -1,0 +1,252 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+type MaybePromise = void | Promise<void>;
+
+/**
+ * Branded symbol so different plugins' slot keys can never collide and the
+ * TypeScript type for `getOrCreateSlot<T>` flows through correctly.
+ */
+export type SlotKey<T> = symbol & { readonly __slotType: T };
+
+/** Observer fired synchronously whenever `slot.notify(next)` is called. */
+export type Observer<T> = (next: T, prev: T) => void;
+
+/** The live state container for one piece of plugin state within a test scope. */
+export type Slot<T> = {
+  /** Current value — mutate collections in-place or call notify() to replace. */
+  readonly value: T;
+  /**
+   * Register a cleanup callback that runs during `_drain()` after the test
+   * body settles, regardless of success or throw. Callbacks are idempotent:
+   * adding the same function reference twice is a no-op.
+   */
+  onDispose(fn: () => MaybePromise): void;
+  /**
+   * Replace the slot value and synchronously fire all registered observers
+   * for this slot key.
+   */
+  notify(next: T): void;
+};
+
+/** Full scope object — created lazily on first plugin access within a test. */
+export type TestScope = {
+  getOrCreateSlot<T>(key: SlotKey<T>, init: () => T): Slot<T>;
+  getSlot<T>(key: SlotKey<T>): Slot<T> | undefined;
+  addObserver<T>(key: SlotKey<T>, fn: Observer<T>): void;
+  addCleanup(fn: () => MaybePromise): void;
+  /** Called by the itBase wrapper after the test body and each.after settle. */
+  _drain(): Promise<void>;
+};
+
+/**
+ * Thin sentinel stored in ALS.  The `scope` property is `undefined` until
+ * a plugin first calls `getOrCreateScope()` — that way tests with no DOM
+ * plugin incur only one object allocation for the holder itself.
+ */
+export type LazyHolder = { scope: TestScope | undefined };
+
+class SlotImpl<T> implements Slot<T> {
+  #value: T;
+  readonly #disposeFns: Set<() => MaybePromise> = new Set();
+  readonly #observers: Set<Observer<T>>;
+
+  constructor(init: T, observers: Set<Observer<T>>) {
+    this.#value = init;
+    this.#observers = observers;
+  }
+
+  get value(): T {
+    return this.#value;
+  }
+
+  onDispose(fn: () => MaybePromise): void {
+    this.#disposeFns.add(fn);
+  }
+
+  notify(next: T): void {
+    const prev = this.#value;
+    this.#value = next;
+    for (const obs of this.#observers) obs(next, prev);
+  }
+
+  async runDispose(): Promise<void> {
+    const fns = [...this.#disposeFns].reverse();
+    this.#disposeFns.clear();
+
+    const errors: unknown[] = [];
+    for (const fn of fns) {
+      try {
+        const r = fn();
+        if (r instanceof Promise) await r;
+      } catch (err) {
+        errors.push(err);
+      }
+    }
+
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) throw new AggregateError(errors, 'Cleanup errors');
+  }
+}
+
+class TestScopeImpl implements TestScope {
+  #slots: Map<symbol, SlotImpl<unknown>> | undefined;
+  #observers: Map<symbol, Set<Observer<unknown>>> | undefined;
+  #globalCleanups: Array<() => MaybePromise> | undefined;
+
+  getOrCreateSlot<T>(key: SlotKey<T>, init: () => T): Slot<T> {
+    if (!this.#slots) this.#slots = new Map();
+    let slot = this.#slots.get(key) as SlotImpl<T> | undefined;
+
+    if (!slot) {
+      const obs = this.#getObservers<T>(key);
+      slot = new SlotImpl<T>(init(), obs as Set<Observer<T>>);
+      this.#slots.set(key, slot as SlotImpl<unknown>);
+    }
+
+    return slot;
+  }
+
+  getSlot<T>(key: SlotKey<T>): Slot<T> | undefined {
+    return this.#slots?.get(key) as SlotImpl<T> | undefined;
+  }
+
+  addObserver<T>(key: SlotKey<T>, fn: Observer<T>): void {
+    const obs = this.#getObservers<T>(key);
+    obs.add(fn);
+  }
+
+  addCleanup(fn: () => MaybePromise): void {
+    if (!this.#globalCleanups) this.#globalCleanups = [];
+    this.#globalCleanups.push(fn);
+  }
+
+  async _drain(): Promise<void> {
+    const errors: unknown[] = [];
+
+    if (this.#slots) {
+      const slots = [...this.#slots.values()].reverse();
+      for (const slot of slots) {
+        try {
+          await slot.runDispose();
+        } catch (err) {
+          errors.push(err);
+        }
+      }
+    }
+
+    if (this.#globalCleanups) {
+      const fns = [...this.#globalCleanups].reverse();
+      this.#globalCleanups = undefined;
+      for (const fn of fns) {
+        try {
+          const r = fn();
+          if (r instanceof Promise) await r;
+        } catch (err) {
+          errors.push(err);
+        }
+      }
+    }
+
+    this.#slots = undefined;
+    this.#observers = undefined;
+
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) throw new AggregateError(errors, 'Scope drain errors');
+  }
+
+  #getObservers<T>(key: SlotKey<T>): Set<Observer<T>> {
+    if (!this.#observers) this.#observers = new Map();
+    let obs = this.#observers.get(key) as Set<Observer<T>> | undefined;
+    if (!obs) {
+      obs = new Set();
+      this.#observers.set(key, obs as Set<Observer<unknown>>);
+    }
+    return obs;
+  }
+}
+
+export const als = new AsyncLocalStorage<LazyHolder>();
+
+/** Create the sentinel object stored in ALS for one test invocation. */
+export const createLazyHolder = (): LazyHolder => ({ scope: undefined });
+
+/**
+ * Wrap `fn` in an ALS context and drain the scope after `fn` settles.
+ * This is the entire poku-side integration: one call per `itBase` invocation.
+ */
+export const runScoped = async (
+  holder: LazyHolder,
+  fn: () => Promise<unknown> | unknown
+): Promise<void> => {
+  await als.run(holder, async () => {
+    const r = fn();
+    if (r instanceof Promise) await r;
+  });
+
+  if (holder.scope) await holder.scope._drain();
+};
+
+/**
+ * Get the current test scope, creating it inside the holder if this is the
+ * first plugin call within the test.  Returns `undefined` when called outside
+ * an `als.run()` context (e.g. top-level module code, beforeAll equivalents).
+ */
+export const getOrCreateScope = (): TestScope | undefined => {
+  const holder = als.getStore();
+  if (!holder) return undefined;
+  if (!holder.scope) holder.scope = new TestScopeImpl();
+  return holder.scope;
+};
+
+/**
+ * Get the current scope without creating it. `undefined` when there is no
+ * active scope or it has not been materialised yet.
+ */
+export const getCurrentScope = (): TestScope | undefined =>
+  als.getStore()?.scope;
+
+/**
+ * Create a typed, globally-unique slot key.
+ * Uses `Symbol.for(name)` so the same key resolves across module re-imports
+ * and serialisation boundaries.
+ *
+ * @example
+ * ```ts
+ * const MOUNTED_KEY = defineSlotKey<Set<InternalMounted>>('@pokujs/react.mounted');
+ * ```
+ */
+export const defineSlotKey = <T>(name: string): SlotKey<T> =>
+  Symbol.for(name) as SlotKey<T>;
+
+const SCOPE_HOOKS_KEY = Symbol.for('@pokujs/poku.test-scope-hooks');
+
+export type ScopeHooks = {
+  createHolder: typeof createLazyHolder;
+  runScoped: typeof runScoped;
+};
+
+type GlobalWithScopeHooks = typeof globalThis & {
+  [SCOPE_HOOKS_KEY]?: ScopeHooks;
+};
+
+/**
+ * Register this scope provider in `globalThis` so poku's `itBase` can pick
+ * it up through the generic hook contract.
+ *
+ * Call this once from the DOM environment setup module (dom-setup-happy.ts /
+ * dom-setup-jsdom.ts).  It is idempotent.
+ */
+export const registerScopeHooks = (): void => {
+  const g = globalThis as GlobalWithScopeHooks;
+  if (!g[SCOPE_HOOKS_KEY]) {
+    g[SCOPE_HOOKS_KEY] = { createHolder: createLazyHolder, runScoped };
+  }
+};
+
+/** Retrieve the registered scope hooks, or `undefined` if not yet registered. */
+export const getScopeHooks = (): ScopeHooks | undefined =>
+  (globalThis as GlobalWithScopeHooks)[SCOPE_HOOKS_KEY];

--- a/tests/test-scope.test.ts
+++ b/tests/test-scope.test.ts
@@ -530,6 +530,53 @@ describe("test-scope: Hook registration (getScopeHooks / registerScopeHooks)", a
 		}
 	});
 
+	await it("registerScopeHooks composes with an existing provider", async () => {
+		const SCOPE_HOOKS_KEY = Symbol.for("@pokujs/poku.test-scope-hooks");
+		type GlobalWithHooks = typeof globalThis & {
+			[key: symbol]: unknown;
+		};
+		const g = globalThis as GlobalWithHooks;
+
+		const original = g[SCOPE_HOOKS_KEY];
+
+		const calls: string[] = [];
+
+		try {
+			g[SCOPE_HOOKS_KEY] = {
+				createHolder: () => ({ scope: { tag: "legacy" } }),
+				runScoped: async (_holder: { scope: unknown }, fn: () => Promise<unknown> | unknown) => {
+					calls.push("legacy:before");
+					const result = fn();
+					if (result instanceof Promise) await result;
+					calls.push("legacy:after");
+				},
+			};
+
+			registerScopeHooks();
+			const hooks = getScopeHooks();
+
+			if (!hooks) {
+				assert.fail("Hooks should be available");
+			}
+
+			await hooks.runScoped(hooks.createHolder(), () => {
+				calls.push("test:run");
+			});
+
+			assert.deepStrictEqual(
+				calls,
+				["legacy:before", "test:run", "legacy:after"],
+				"Existing provider still wraps execution after DOM registration",
+			);
+		} finally {
+			if (original !== undefined) {
+				g[SCOPE_HOOKS_KEY] = original;
+			} else {
+				delete g[SCOPE_HOOKS_KEY];
+			}
+		}
+	});
+
 	await it("getScopeHooks returns undefined before registration", async () => {
 		const SCOPE_HOOKS_KEY = Symbol.for("@pokujs/poku.test-scope-hooks");
 		type GlobalWithHooks = typeof globalThis & {

--- a/tests/test-scope.test.ts
+++ b/tests/test-scope.test.ts
@@ -1,0 +1,643 @@
+import { assert, describe, it } from "poku";
+import {
+	als,
+	createLazyHolder,
+	defineSlotKey,
+	getCurrentScope,
+	getOrCreateScope,
+	getScopeHooks,
+	type LazyHolder,
+	type Observer,
+	registerScopeHooks,
+	runScoped,
+	type TestScope,
+} from "../src/test-scope.ts";
+
+// Helper: Get scope with assertion guard for use within runScoped() contexts
+function ensureScope(): TestScope {
+	const scope = getOrCreateScope();
+	if (!scope) {
+		assert.fail(
+			"Scope must exist inside runScoped() context - this is a test bug",
+		);
+	}
+	return scope;
+}
+
+describe("test-scope: TypeScript slot keys", async () => {
+	await it("defineSlotKey creates branded symbol keys", async () => {
+		const KEY_A = defineSlotKey<string>("@test/key-a");
+		const KEY_B = defineSlotKey<number>("@test/key-b");
+		const KEY_A_AGAIN = defineSlotKey<string>("@test/key-a");
+
+		// Same name returns same symbol (Symbol.for)
+		assert.strictEqual(KEY_A, KEY_A_AGAIN, "Same name gives same symbol");
+		// Different names give different symbols
+		assert.notStrictEqual(
+			KEY_A,
+			KEY_B,
+			"Different names give different symbols",
+		);
+		// Symbols are symbols
+		assert.strictEqual(typeof KEY_A, "symbol", "Key is a symbol");
+	});
+});
+
+describe("test-scope: ALS laziness & holder creation", async () => {
+	await it("createLazyHolder creates sentinel with undefined scope", async () => {
+		const holder = createLazyHolder();
+		assert.ok(holder, "Holder is defined");
+		assert.strictEqual(holder.scope, undefined, "Initial scope is undefined");
+	});
+
+	await it("getOrCreateScope returns undefined outside ALS context", async () => {
+		const scope = getOrCreateScope();
+		assert.strictEqual(scope, undefined, "No scope outside ALS context");
+	});
+
+	await it("getCurrentScope returns undefined when no scope exists", async () => {
+		const scope = getCurrentScope();
+		assert.strictEqual(scope, undefined, "No current scope");
+	});
+});
+
+describe("test-scope: Lazy scope initialization in ALS", async () => {
+	await it("runScoped creates ALS context with holder", async () => {
+		const holder = createLazyHolder();
+		let capturedHolder: LazyHolder | undefined;
+		let capturedScope: TestScope | undefined;
+
+		await runScoped(holder, () => {
+			capturedHolder = als.getStore();
+			capturedScope = getOrCreateScope();
+		});
+
+		assert.strictEqual(
+			capturedHolder,
+			holder,
+			"Runner receives original holder",
+		);
+		assert.ok(
+			capturedScope,
+			"Scope is created on first plugin call inside runScoped",
+		);
+		assert.strictEqual(
+			holder.scope,
+			capturedScope,
+			"Holder.scope is set by getOrCreateScope",
+		);
+	});
+
+	await it("getOrCreateScope is idempotent within same holder", async () => {
+		const holder = createLazyHolder();
+		let scope1: TestScope | undefined;
+		let scope2: TestScope | undefined;
+
+		await runScoped(holder, () => {
+			scope1 = getOrCreateScope();
+			scope2 = getOrCreateScope();
+		});
+
+		assert.strictEqual(scope1, scope2, "Same scope object returned");
+	});
+
+	await it("getCurrentScope returns holder.scope without creating", async () => {
+		const holder = createLazyHolder();
+
+		await runScoped(holder, () => {
+			// First call creates it
+			const s1 = getOrCreateScope();
+			// Now getCurrentScope should return it
+			const s2 = getCurrentScope();
+			assert.strictEqual(s1, s2, "getCurrentScope returns existing scope");
+		});
+	});
+});
+
+describe("test-scope: Slot creation & value management", async () => {
+	await it("getOrCreateSlot initializes with init() result", async () => {
+		const holder = createLazyHolder();
+		const KEY = defineSlotKey<number>("@test/number-slot");
+
+		await runScoped(holder, () => {
+			const scope = ensureScope();
+			const slot = scope.getOrCreateSlot(KEY, () => 42);
+			assert.strictEqual(slot.value, 42, "Slot initialized to init() value");
+		});
+	});
+
+	await it("getOrCreateSlot returns same slot on repeated calls", async () => {
+		const holder = createLazyHolder();
+		const KEY = defineSlotKey<boolean>("@test/bool-slot");
+
+		await runScoped(holder, () => {
+			const scope = ensureScope();
+			const slot1 = scope.getOrCreateSlot(KEY, () => true);
+			const slot2 = scope.getOrCreateSlot(KEY, () => false);
+			assert.strictEqual(slot1, slot2, "Same slot returned");
+			assert.strictEqual(slot2.value, true, "Still has first init value");
+		});
+	});
+
+	await it("getSlot retrieves without creating", async () => {
+		const holder = createLazyHolder();
+		const KEY = defineSlotKey<string>("@test/string-slot");
+
+		await runScoped(holder, () => {
+			const scope = ensureScope();
+			// Before creation
+			let slot = scope.getSlot(KEY);
+			assert.strictEqual(slot, undefined, "Not created yet");
+
+			// After creation
+			scope.getOrCreateSlot(KEY, () => "hello");
+			slot = scope.getSlot(KEY);
+			assert.ok(slot, "Slot found after creation");
+			assert.strictEqual(slot?.value, "hello", "Slot has correct value");
+		});
+	});
+});
+
+describe("test-scope: Slot value mutation & notification", async () => {
+	await it("notify() updates slot value and fires observers", async () => {
+		const holder = createLazyHolder();
+		const KEY = defineSlotKey<number>("@test/notify-slot");
+		const notifications: Array<[number, number]> = [];
+
+		const observer: Observer<number> = (next, prev) => {
+			notifications.push([next, prev]);
+		};
+
+		await runScoped(holder, () => {
+			const scope = ensureScope();
+			const slot = scope.getOrCreateSlot(KEY, () => 1);
+			scope.addObserver(KEY, observer);
+
+			slot.notify(2);
+			slot.notify(3);
+
+			assert.strictEqual(slot.value, 3, "Value is latest notified value");
+			assert.strictEqual(notifications.length, 2, "Two notifications fired");
+			assert.deepStrictEqual(
+				notifications[0],
+				[2, 1],
+				"First notification is (2, 1)",
+			);
+			assert.deepStrictEqual(
+				notifications[1],
+				[3, 2],
+				"Second notification is (3, 2)",
+			);
+		});
+	});
+
+	await it("multiple observers all fire on notify", async () => {
+		const holder = createLazyHolder();
+		const KEY = defineSlotKey<number>("@test/multi-observer-slot");
+		const calls: string[] = [];
+
+		await runScoped(holder, () => {
+			const scope = ensureScope();
+			const slot = scope.getOrCreateSlot(KEY, () => 0);
+
+			scope.addObserver(KEY, () => calls.push("A"));
+			scope.addObserver(KEY, () => calls.push("B"));
+			scope.addObserver(KEY, () => calls.push("C"));
+
+			slot.notify(1);
+
+			assert.strictEqual(calls.length, 3, "All observers fired");
+			assert.ok(
+				calls.includes("A") && calls.includes("B") && calls.includes("C"),
+				"All observers called",
+			);
+		});
+	});
+});
+
+describe("test-scope: onDispose callbacks (LIFO & error handling)", async () => {
+	await it("onDispose callbacks execute in LIFO order", async () => {
+		const holder = createLazyHolder();
+		const KEY = defineSlotKey<Set<string>>("@test/dispose-slot");
+		const order: string[] = [];
+
+		await runScoped(holder, () => {
+			const scope = ensureScope();
+			const slot = scope.getOrCreateSlot(KEY, () => new Set());
+
+			slot.onDispose(() => {order.push("first")});
+			slot.onDispose(() => {order.push("second")});
+			slot.onDispose(() => {order.push("third")});
+		});
+
+		// After runScoped, drain has run
+		assert.deepStrictEqual(order, ["third", "second", "first"], "LIFO order");
+	});
+
+	await it("onDispose idempotent: duplicate functions added only once", async () => {
+		const holder = createLazyHolder();
+		const KEY = defineSlotKey<Set<string>>("@test/idempotent-dispose");
+		let count = 0;
+
+		const fn = () => {
+			count++;
+		};
+
+		await runScoped(holder, () => {
+			const scope = ensureScope();
+			const slot = scope.getOrCreateSlot(KEY, () => new Set());
+
+			slot.onDispose(fn);
+			slot.onDispose(fn); // Add same function again
+			slot.onDispose(fn); // Again
+		});
+
+		assert.strictEqual(count, 1, "Function runs once despite multiple adds");
+	});
+
+	await it("onDispose handles promise-returning cleanup functions", async () => {
+		const holder = createLazyHolder();
+		const KEY = defineSlotKey<Set<string>>("@test/async-dispose-slot");
+		const order: string[] = [];
+
+		await runScoped(holder, () => {
+			const scope = ensureScope();
+			const slot = scope.getOrCreateSlot(KEY, () => new Set());
+
+			slot.onDispose(() => {
+				order.push("sync");
+			});
+
+			slot.onDispose(async () => {
+				await new Promise((resolve) => setTimeout(resolve, 10));
+				order.push("async");
+			});
+		});
+
+		assert.deepStrictEqual(
+			order,
+			["async", "sync"],
+			"Async cleanup completes, then sync",
+		);
+	});
+
+	await it("single error in onDispose is rethrown", async () => {
+		const holder = createLazyHolder();
+		const KEY = defineSlotKey<Set<string>>("@test/error-dispose-slot");
+
+		await assert.rejects(
+			() =>
+				runScoped(holder, () => {
+					const scope = ensureScope();
+					const slot = scope.getOrCreateSlot(KEY, () => new Set());
+					slot.onDispose(() => {
+						throw new Error("Test error");
+					});
+				}),
+			Error,
+			"Test error",
+		);
+	});
+
+	await it("multiple errors in onDispose are aggregated", async () => {
+		const holder = createLazyHolder();
+		const KEY = defineSlotKey<Set<string>>("@test/multi-error-dispose-slot");
+
+		await assert.rejects(
+			() =>
+				runScoped(holder, () => {
+					const scope = ensureScope();
+					const slot = scope.getOrCreateSlot(KEY, () => new Set());
+
+					slot.onDispose(() => {
+						throw new Error("Error 1");
+					});
+					slot.onDispose(() => {
+						throw new Error("Error 2");
+					});
+				}),
+			(err: unknown) => {
+				assert.ok(err instanceof AggregateError, "AggregateError thrown");
+				const agg = err as AggregateError;
+				assert.strictEqual(agg.errors.length, 2, "Two errors aggregated");
+				assert.strictEqual(
+					(agg.errors[0] as Error).message,
+					"Error 2",
+					"First is last-added",
+				);
+				assert.strictEqual(
+					(agg.errors[1] as Error).message,
+					"Error 1",
+					"Second is first-added",
+				);
+				return true;
+			},
+		);
+	});
+});
+
+describe("test-scope: Scope-level cleanups via addCleanup", async () => {
+	await it("addCleanup callbacks execute in LIFO order", async () => {
+		const holder = createLazyHolder();
+		const order: string[] = [];
+
+		await runScoped(holder, () => {
+			const scope = ensureScope();
+			scope.addCleanup(() => {order.push("first")});
+			scope.addCleanup(() => {order.push("second")});
+			scope.addCleanup(() => {order.push("third")});
+		});
+
+		assert.deepStrictEqual(order, ["third", "second", "first"], "LIFO order");
+	});
+
+	await it("slot disposals run before scope cleanups", async () => {
+		const holder = createLazyHolder();
+		const KEY = defineSlotKey<Set<string>>("@test/order-dispose-cleanup");
+		const order: string[] = [];
+
+		await runScoped(holder, () => {
+			const scope = ensureScope();
+			const slot = scope.getOrCreateSlot(KEY, () => new Set());
+
+			scope.addCleanup(() => {order.push("scope-cleanup-1")});
+			slot.onDispose(() => {order.push("slot-dispose")});
+			scope.addCleanup(() => {order.push("scope-cleanup-2")});
+		});
+
+		assert.deepStrictEqual(
+			order,
+			["slot-dispose", "scope-cleanup-2", "scope-cleanup-1"],
+			"Slot disposals run, then scope cleanups in LIFO order",
+		);
+	});
+
+	await it("scope cleanup handles async functions", async () => {
+		const holder = createLazyHolder();
+		const order: string[] = [];
+
+		await runScoped(holder, () => {
+			const scope = ensureScope();
+
+			scope.addCleanup(async () => {
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				order.push("async-1");
+			});
+
+			scope.addCleanup(async () => {
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				order.push("async-2");
+			});
+		});
+
+		assert.deepStrictEqual(
+			order,
+			["async-2", "async-1"],
+			"Async cleanups in LIFO",
+		);
+	});
+
+	await it("error in scope cleanup is thrown", async () => {
+		const holder = createLazyHolder();
+
+		await assert.rejects(
+			() =>
+				runScoped(holder, () => {
+					const scope = ensureScope();
+					scope.addCleanup(() => {
+						throw new Error("Cleanup error");
+					});
+				}),
+			Error,
+			"Cleanup error",
+		);
+	});
+});
+
+describe("test-scope: Concurrent isolation via ALS", async () => {
+	await it("concurrent runScoped calls get isolated scopes", async () => {
+		const KEY = defineSlotKey<{ id: number }>("@test/concurrent-isolation");
+		const results: Array<{ id: number; otherIds: number[] }> = [];
+
+		let idSeed = 0;
+
+		const runTestA = async () => {
+			const holder = createLazyHolder();
+			await runScoped(holder, () => {
+				const scope = ensureScope();
+				const slot = scope.getOrCreateSlot(KEY, () => ({ id: ++idSeed }));
+				const myId = slot.value.id;
+
+				// Small async operation to ensure task context is maintained
+				return new Promise<void>((resolve) => {
+					setTimeout(() => {
+						const retrieved = ensureScope().getSlot(KEY);
+						results.push({
+							id: myId,
+							otherIds: retrieved ? [retrieved.value.id] : [],
+						});
+						resolve();
+					}, 5);
+				});
+			});
+		};
+
+		const runTestB = async () => {
+			const holder = createLazyHolder();
+			await runScoped(holder, () => {
+				const scope = ensureScope();
+				const slot = scope.getOrCreateSlot(KEY, () => ({ id: ++idSeed }));
+				const myId = slot.value.id;
+
+				return new Promise<void>((resolve) => {
+					setTimeout(() => {
+						const retrieved = ensureScope().getSlot(KEY);
+						results.push({
+							id: myId,
+							otherIds: retrieved ? [retrieved.value.id] : [],
+						});
+						resolve();
+					}, 5);
+				});
+			});
+		};
+
+		await Promise.all([runTestA(), runTestB()]);
+
+		// Each test should have seen its own id
+		assert.strictEqual(results.length, 2, "Two results");
+
+    if (!results[0] || !results[1]) {
+      assert.fail("Results should be defined");
+    }
+
+		assert.ok(
+			results[0].otherIds[0] === results[0].id &&
+				results[1].otherIds[0] === results[1].id,
+			"Each test maintains its own slot",
+		);
+		assert.notStrictEqual(
+			results[0].id,
+			results[1].id,
+			"Different tests have different ids",
+		);
+	});
+});
+
+describe("test-scope: Hook registration (getScopeHooks / registerScopeHooks)", async () => {
+	await it("registerScopeHooks idempotently registers hooks", async () => {
+		// Clean state for this test
+		const SCOPE_HOOKS_KEY = Symbol.for("@pokujs/poku.test-scope-hooks");
+		type GlobalWithHooks = typeof globalThis & {
+			[key: symbol]: unknown;
+		};
+		const g = globalThis as GlobalWithHooks;
+
+		// Save original
+		const original = g[SCOPE_HOOKS_KEY];
+
+		try {
+			// Clear it
+			delete g[SCOPE_HOOKS_KEY];
+
+			// First register
+			registerScopeHooks();
+			const hooks1 = getScopeHooks();
+      if (!hooks1) {
+        assert.fail("Hooks should be registered");
+      }
+
+			assert.ok(
+				"createHolder" in hooks1 && "runScoped" in hooks1,
+				"Hooks have required methods",
+			);
+
+			// Second register (should not overwrite)
+			registerScopeHooks();
+			const hooks2 = getScopeHooks();
+			assert.strictEqual(
+				hooks1,
+				hooks2,
+				"Same hooks instance returned (idempotent)",
+			);
+		} finally {
+			// Restore
+			if (original !== undefined) {
+				g[SCOPE_HOOKS_KEY] = original;
+			} else {
+				delete g[SCOPE_HOOKS_KEY];
+			}
+		}
+	});
+
+	await it("getScopeHooks returns undefined before registration", async () => {
+		const SCOPE_HOOKS_KEY = Symbol.for("@pokujs/poku.test-scope-hooks");
+		type GlobalWithHooks = typeof globalThis & {
+			[key: symbol]: unknown;
+		};
+		const g = globalThis as GlobalWithHooks;
+
+		// Save and clear
+		const original = g[SCOPE_HOOKS_KEY];
+		delete g[SCOPE_HOOKS_KEY];
+
+		try {
+			const hooks = getScopeHooks();
+			assert.strictEqual(hooks, undefined, "No hooks before registration");
+		} finally {
+			if (original !== undefined) {
+				g[SCOPE_HOOKS_KEY] = original;
+			}
+		}
+	});
+});
+
+describe("test-scope: Integration - multiple slots in one scope", async () => {
+	await it("scope maintains multiple independent slots", async () => {
+		const holder = createLazyHolder();
+		const STRINGS_KEY = defineSlotKey<string[]>("@test/strings");
+		const NUMBERS_KEY = defineSlotKey<number[]>("@test/numbers");
+
+		await runScoped(holder, () => {
+			const scope = ensureScope();
+
+			const stringsSlot = scope.getOrCreateSlot(STRINGS_KEY, () => []);
+			const numbersSlot = scope.getOrCreateSlot(NUMBERS_KEY, () => []);
+
+			stringsSlot.value.push("hello", "world");
+			numbersSlot.value.push(1, 2, 3);
+
+			assert.deepStrictEqual(
+				stringsSlot.value,
+				["hello", "world"],
+				"String slot unchanged",
+			);
+			assert.deepStrictEqual(
+				numbersSlot.value,
+				[1, 2, 3],
+				"Number slot unchanged",
+			);
+		});
+	});
+
+	await it("multiple slots can observe and notify independently", async () => {
+		const holder = createLazyHolder();
+		const KEY_A = defineSlotKey<number>("@test/observ-a");
+		const KEY_B = defineSlotKey<string>("@test/observ-b");
+
+		const callsA: Array<[number, number]> = [];
+		const callsB: Array<[string, string]> = [];
+
+		await runScoped(holder, () => {
+			const scope = ensureScope();
+
+			const slotA = scope.getOrCreateSlot(KEY_A, () => 0);
+			const slotB = scope.getOrCreateSlot(KEY_B, () => "");
+
+			scope.addObserver(KEY_A, (n, p) => callsA.push([n, p]));
+			scope.addObserver(KEY_B, (n, p) => callsB.push([n, p]));
+
+			slotA.notify(1);
+			slotB.notify("x");
+			slotA.notify(2);
+			slotB.notify("y");
+		});
+
+		assert.deepStrictEqual(
+			callsA,
+			[
+				[1, 0],
+				[2, 1],
+			],
+			"A notifications",
+		);
+		assert.deepStrictEqual(
+			callsB,
+			[
+				["x", ""],
+				["y", "x"],
+			],
+			"B notifications",
+		);
+	});
+});
+
+describe("test-scope: Memory cleanup & GC friendliness", async () => {
+	await it("_drain clears internal maps to aid GC", async () => {
+		const holder = createLazyHolder();
+		const KEY = defineSlotKey<number>("@test/gc-slot");
+
+		await runScoped(holder, () => {
+			const scope = ensureScope();
+			scope.getOrCreateSlot(KEY, () => 42);
+			scope.addCleanup(() => {});
+		});
+
+		// After drain, scope internals should be cleared
+		// We verify by calling _drain again (should not error even with no slots/cleanups)
+		if (holder.scope) {
+			await holder.scope._drain();
+			// Should complete without error
+		}
+	});
+});

--- a/tests/test-scope.test.ts
+++ b/tests/test-scope.test.ts
@@ -1,17 +1,19 @@
-import { assert, describe, it } from "poku";
+import { afterEach, assert, beforeEach, describe, it } from "poku";
+import { getScopeHooks } from "@pokujs/scope-hooks";
 import {
 	als,
 	createLazyHolder,
 	defineSlotKey,
 	getCurrentScope,
 	getOrCreateScope,
-	getScopeHooks,
 	type LazyHolder,
 	type Observer,
 	registerScopeHooks,
 	runScoped,
 	type TestScope,
 } from "../src/test-scope.ts";
+
+const SCOPE_HOOKS_KEY = Symbol.for('@pokujs/poku.test-scope-hooks');
 
 // Helper: Get scope with assertion guard for use within runScoped() contexts
 function ensureScope(): TestScope {
@@ -485,117 +487,86 @@ describe("test-scope: Concurrent isolation via ALS", async () => {
 });
 
 describe("test-scope: Hook registration (getScopeHooks / registerScopeHooks)", async () => {
+  type GlobalWithHooks = typeof globalThis & {
+    [key: symbol]: unknown;
+  };
+  const g = globalThis as GlobalWithHooks;
+  let originalHooks: unknown;
+
+  beforeEach(() => {
+    originalHooks = g[SCOPE_HOOKS_KEY];
+    delete g[SCOPE_HOOKS_KEY];
+  });
+
+  afterEach(() => {
+    if (originalHooks === undefined) {
+      delete g[SCOPE_HOOKS_KEY];
+    } else {
+      g[SCOPE_HOOKS_KEY] = originalHooks;
+    }
+    originalHooks = undefined;
+  });
+
 	await it("registerScopeHooks idempotently registers hooks", async () => {
-		// Clean state for this test
-		const SCOPE_HOOKS_KEY = Symbol.for("@pokujs/poku.test-scope-hooks");
-		type GlobalWithHooks = typeof globalThis & {
-			[key: symbol]: unknown;
-		};
-		const g = globalThis as GlobalWithHooks;
-
-		// Save original
-		const original = g[SCOPE_HOOKS_KEY];
-
-		try {
-			// Clear it
-			delete g[SCOPE_HOOKS_KEY];
-
-			// First register
-			registerScopeHooks();
-			const hooks1 = getScopeHooks();
-      if (!hooks1) {
-        assert.fail("Hooks should be registered");
-      }
-
-			assert.ok(
-				"createHolder" in hooks1 && "runScoped" in hooks1,
-				"Hooks have required methods",
-			);
-
-			// Second register (should not overwrite)
-			registerScopeHooks();
-			const hooks2 = getScopeHooks();
-			assert.strictEqual(
-				hooks1,
-				hooks2,
-				"Same hooks instance returned (idempotent)",
-			);
-		} finally {
-			// Restore
-			if (original !== undefined) {
-				g[SCOPE_HOOKS_KEY] = original;
-			} else {
-				delete g[SCOPE_HOOKS_KEY];
-			}
+		// First register
+		registerScopeHooks();
+		const hooks1 = getScopeHooks();
+		if (!hooks1) {
+			assert.fail("Hooks should be registered");
 		}
+
+		assert.ok(
+			"createHolder" in hooks1 && "runScoped" in hooks1,
+			"Hooks have required methods",
+		);
+
+		// Second register (should not overwrite)
+		registerScopeHooks();
+		const hooks2 = getScopeHooks();
+		assert.strictEqual(
+			hooks1,
+			hooks2,
+			"Same hooks instance returned (idempotent)",
+		);
 	});
 
 	await it("registerScopeHooks composes with an existing provider", async () => {
-		const SCOPE_HOOKS_KEY = Symbol.for("@pokujs/poku.test-scope-hooks");
-		type GlobalWithHooks = typeof globalThis & {
-			[key: symbol]: unknown;
-		};
-		const g = globalThis as GlobalWithHooks;
-
-		const original = g[SCOPE_HOOKS_KEY];
-
 		const calls: string[] = [];
+		g[SCOPE_HOOKS_KEY] = {
+			createHolder: () => ({ scope: { tag: "legacy" } }),
+			runScoped: async (_holder: { scope: unknown }, fn: () => Promise<unknown> | unknown) => {
+				calls.push("legacy:before");
+				const result = fn();
+				if (result instanceof Promise) await result;
+				calls.push("legacy:after");
+			},
+		};
 
-		try {
-			g[SCOPE_HOOKS_KEY] = {
-				createHolder: () => ({ scope: { tag: "legacy" } }),
-				runScoped: async (_holder: { scope: unknown }, fn: () => Promise<unknown> | unknown) => {
-					calls.push("legacy:before");
-					const result = fn();
-					if (result instanceof Promise) await result;
-					calls.push("legacy:after");
-				},
-			};
+		registerScopeHooks();
+		const hooks = getScopeHooks();
 
-			registerScopeHooks();
-			const hooks = getScopeHooks();
-
-			if (!hooks) {
-				assert.fail("Hooks should be available");
-			}
-
-			await hooks.runScoped(hooks.createHolder(), () => {
-				calls.push("test:run");
-			});
-
-			assert.deepStrictEqual(
-				calls,
-				["legacy:before", "test:run", "legacy:after"],
-				"Existing provider still wraps execution after DOM registration",
-			);
-		} finally {
-			if (original !== undefined) {
-				g[SCOPE_HOOKS_KEY] = original;
-			} else {
-				delete g[SCOPE_HOOKS_KEY];
-			}
+		if (!hooks) {
+			assert.fail("Hooks should be available");
 		}
+
+		await hooks.runScoped(hooks.createHolder(), () => {
+			calls.push("test:run");
+		});
+
+		assert.deepStrictEqual(
+			calls,
+			[
+				"legacy:before",
+				"test:run",
+				"legacy:after",
+			],
+			"Existing provider remains visible after DOM registration",
+		);
 	});
 
 	await it("getScopeHooks returns undefined before registration", async () => {
-		const SCOPE_HOOKS_KEY = Symbol.for("@pokujs/poku.test-scope-hooks");
-		type GlobalWithHooks = typeof globalThis & {
-			[key: symbol]: unknown;
-		};
-		const g = globalThis as GlobalWithHooks;
-
-		// Save and clear
-		const original = g[SCOPE_HOOKS_KEY];
-		delete g[SCOPE_HOOKS_KEY];
-
-		try {
-			const hooks = getScopeHooks();
-			assert.strictEqual(hooks, undefined, "No hooks before registration");
-		} finally {
-			if (original !== undefined) {
-				g[SCOPE_HOOKS_KEY] = original;
-			}
-		}
+		const hooks = getScopeHooks();
+		assert.strictEqual(hooks, undefined, "No hooks before registration");
 	});
 });
 


### PR DESCRIPTION
## Summary
- add a generic ALS-based test scope provider in dom
- register scope hooks in DOM environment setup (happy-dom and jsdom)
- export scope API from package index
- add comprehensive tests for scope lifecycle, cleanup ordering, observer behavior, concurrency isolation, and hook registration

## Why
This establishes the plugin-agnostic scope infrastructure needed for per-test state isolation via poku's generic scope-hook contract.

## Notes
- This is foundational wiring in dom; framework packages can now migrate from module-level global sets to per-test slots backed by this scope API.
- Compatible with poku versions that do not implement scope hooks in core, because core falls back when hooks are absent and registration on dom side is non-breaking.

## Validation
- npm run lint
- npm test