### PR TITLE
fix: use --preload for Bun instead of --import

### DIFF
--- a/src/plugin-command.ts
+++ b/src/plugin-command.ts
@@ -82,6 +82,7 @@ export const buildRunnerCommand = ({
   if (fileIndex === -1) return { shouldHandle: false, command };
 
   const nodeImportFlag = `--import=${domSetupPath}`;
+  const bunPreloadFlag = `--preload ${domSetupPath}`;
   const denoPreloadFlag = `--preload=${domSetupPath}`;
   const beforeFile: string[] = [];
   const afterFile: string[] = [];
@@ -114,7 +115,11 @@ export const buildRunnerCommand = ({
   const extraImports: string[] = [];
   if (isNodeRuntime(runtime) && !hasTsx) extraImports.push('--import=tsx');
   if (support.supportsNodeLikeImport && !hasNodeLikeDomSetup) {
-    extraImports.push(nodeImportFlag);
+    if (isBunRuntime(runtime)) {
+      extraImports.push(bunPreloadFlag);
+    } else {
+      extraImports.push(nodeImportFlag);
+    }
   }
   if (support.supportsDenoPreload && !hasDenoDomSetup) {
     extraImports.push(denoPreloadFlag);

--- a/tests/plugin-command.test.ts
+++ b/tests/plugin-command.test.ts
@@ -32,6 +32,24 @@ test('buildRunnerCommand injects runtime setup flags', async () => {
   ]);
 });
 
+test('buildRunnerCommand injects --preload for Bun (not --import)', async () => {
+  const result = buildRunnerCommand({
+    runtime: 'bun',
+    command: ['bun', 'tests/example.test.tsx'],
+    file: 'tests/example.test.tsx',
+    domSetupPath: '/tmp/dom-setup.ts',
+    runtimeOptionArgs: [],
+    extensions: new Set(['.tsx', '.jsx']),
+  });
+
+  assert.strictEqual(result.shouldHandle, true);
+  assert.deepStrictEqual(result.command, [
+    'bun',
+    '--preload /tmp/dom-setup.ts',
+    'tests/example.test.tsx',
+  ]);
+});
+
 test('buildRunnerCommand leaves unsupported files unchanged', async () => {
   const command = ['node', 'tests/example.test.ts'];
   const result = buildRunnerCommand({


### PR DESCRIPTION
## Summary

- Use \`--preload\` flag for Bun instead of \`--import=\` as Bun uses positional arguments for preload
- Added \`bunPreloadFlag\` constant in plugin-command.ts
- Added branch in extraImports logic to select correct flag based on runtime

## Fix Details

Bun requires \`--preload\` as a positional argument (e.g., \`--preload /path/to/file\`) rather than \`--import=/path/to/file\` which is used for Node.js and Deno. This fix updates the plugin-command to properly handle Bun's CLI arguments.

## Test

Added test case verifying that \`buildRunnerCommand\` produces \`--preload /tmp/dom-setup.ts\` for Bun runtime instead of \`--import=\`.